### PR TITLE
Get snapshot of pdf through open-terms-archive package

### DIFF
--- a/src/hooks/useUrl.tsx
+++ b/src/hooks/useUrl.tsx
@@ -69,7 +69,10 @@ const useUrl = () => {
       const newParsed = queryString.stringify(newUrlParams);
 
       const newUrl = `${pathname}${newParsed ? `?${newParsed}` : ''}`;
-      router.push(newUrl, as, options);
+
+      if (router.asPath !== newUrl) {
+        router.push(newUrl, as, options);
+      }
       return newUrl;
     },
     [router, pathname, queryParams]

--- a/src/modules/Common/services/open-terms-archive.ts
+++ b/src/modules/Common/services/open-terms-archive.ts
@@ -14,7 +14,7 @@ interface OTADocumentDeclaration {
 
 type OTAVersion = string;
 
-interface Snapshot {
+export interface Snapshot {
   content: string;
   mimeType: string;
   documentDeclaration: OTADocumentDeclaration;

--- a/src/modules/Common/services/open-terms-archive.ts
+++ b/src/modules/Common/services/open-terms-archive.ts
@@ -1,6 +1,12 @@
 import fetch, { launchHeadlessBrowser, stopHeadlessBrowser } from 'open-terms-archive/fetch';
 import filter from 'open-terms-archive/filter';
 
+export interface OTAJson {
+  name: string;
+  documents: {
+    [key: string]: OTADocumentDeclaration;
+  };
+}
 interface OTASnapshot {
   content: string;
   mimeType: string;

--- a/src/modules/Common/services/open-terms-archive.ts
+++ b/src/modules/Common/services/open-terms-archive.ts
@@ -1,9 +1,31 @@
 import fetch, { launchHeadlessBrowser, stopHeadlessBrowser } from 'open-terms-archive/fetch';
 import filter from 'open-terms-archive/filter';
 
-export const getVersion = async (documentDeclaration: any, config: any) => {
+interface OTASnapshot {
+  content: string;
+  mimeType: string;
+}
+interface OTADocumentDeclaration {
+  fetch: string;
+  select?: any;
+  remove?: any;
+  executeClientScripts?: boolean;
+}
+
+type OTAVersion = string;
+
+interface Snapshot {
+  content: string;
+  mimeType: string;
+  documentDeclaration: OTADocumentDeclaration;
+}
+
+export const getSnapshot = async (
+  documentDeclaration: OTADocumentDeclaration,
+  config: any
+): Promise<Snapshot> => {
   await launchHeadlessBrowser();
-  const { content, mimeType } = await fetch({
+  const { content, mimeType }: OTASnapshot = await fetch({
     url: documentDeclaration.fetch,
     executeClientScripts: documentDeclaration.executeClientScripts,
     cssSelectors: documentDeclaration.select,
@@ -11,7 +33,19 @@ export const getVersion = async (documentDeclaration: any, config: any) => {
   });
   await stopHeadlessBrowser();
 
-  const version = await filter({
+  return {
+    content,
+    mimeType,
+    documentDeclaration,
+  };
+};
+
+export const getVersionFromSnapshot = async ({
+  content,
+  mimeType,
+  documentDeclaration,
+}: Snapshot) => {
+  const version: OTAVersion = await filter({
     content,
     mimeType,
     documentDeclaration: {
@@ -20,11 +54,18 @@ export const getVersion = async (documentDeclaration: any, config: any) => {
       noiseSelectors: documentDeclaration.remove,
     },
   });
+
   return {
     version,
     snapshot: content,
     mimeType,
   };
+};
+
+export const getVersion = async (documentDeclaration: OTADocumentDeclaration, config: any) => {
+  const snapshot = await getSnapshot(documentDeclaration, config);
+
+  return getVersionFromSnapshot(snapshot);
 };
 
 export const launchBrowser = launchHeadlessBrowser;

--- a/src/modules/Contribute/interfaces/index.ts
+++ b/src/modules/Contribute/interfaces/index.ts
@@ -3,7 +3,7 @@ import { CommonResponse } from 'interfaces';
 export interface GetContributeServiceResponse extends CommonResponse {
   url: string;
   error?: string;
-  isPdf?: boolean;
+  isPDF?: boolean;
 }
 export interface PostContributeServiceResponse extends CommonResponse {
   url?: string;

--- a/src/modules/Scraper/utils/downloader.ts
+++ b/src/modules/Scraper/utils/downloader.ts
@@ -106,10 +106,10 @@ export const downloadUrl = async (
     json.select = ['html'];
   }
 
-  let data;
+  let snapshot: Snapshot;
 
   try {
-    data = await getVersion(json, { language: acceptLanguage });
+    snapshot = await getSnapshot(json, { language: acceptLanguage });
   } catch (e: any) {
     console.error(e.toString());
     fse.removeSync(folderPath);
@@ -195,7 +195,7 @@ export const downloadUrl = async (
       waitUntil: 'networkidle0', // same as in OTA Core
       timeout: 30000,
     });
-    await page.setContent(data.snapshot);
+    await page.setContent(snapshot.content);
 
     await addMissingStyledComponents(page);
     await removeBaseTag(page);

--- a/src/modules/Scraper/utils/downloader.ts
+++ b/src/modules/Scraper/utils/downloader.ts
@@ -12,7 +12,12 @@ import fse from 'fs-extra';
 import type { Page, Browser } from 'puppeteer'; // from open-terms-archive
 import puppeteer from 'puppeteer-extra'; // from open-terms-archive
 const logDebug = debug('ota.org:debug');
-import { getVersion, stopBrowser, launchBrowser } from 'modules/Common/services/open-terms-archive';
+import {
+  getSnapshot,
+  Snapshot,
+  stopBrowser,
+  launchBrowser,
+} from 'modules/Common/services/open-terms-archive';
 
 puppeteer.use(RecaptchaPlugin());
 
@@ -83,6 +88,11 @@ const cleanHtml = (html: string, assets: { from: string; to: string }[]) => {
   return filteredHtml;
 };
 
+type DownloadResult = {
+  url: string;
+  isPDF?: boolean;
+};
+
 export const downloadUrl = async (
   json: any,
   {
@@ -90,12 +100,28 @@ export const downloadUrl = async (
     newUrlPath,
     acceptLanguage = 'en',
   }: { folderPath: string; newUrlPath: string; acceptLanguage?: string }
-) => {
+): Promise<DownloadResult> => {
   const url = json.fetch;
   const snapshotFilePath = `${folderPath}/snapshot.html`;
   const indexFilePath = `${folderPath}/index.html`;
+  const newUrl = `${newUrlPath}/index.html`;
 
-  fse.ensureFileSync(indexFilePath);
+  const snapshotPDFFilePath = `${folderPath}/snapshot.pdf`;
+  const newPDFUrl = `${newUrlPath}/snapshot.pdf`;
+
+  if (fse.existsSync(folderPath)) {
+    const existingFiles = fse.readdirSync(folderPath);
+    if (existingFiles.includes('snapshot.pdf')) {
+      return { url: newPDFUrl, isPDF: true };
+    }
+    return { url: newUrl };
+  }
+
+  fse.ensureDirSync(folderPath);
+  const timerLabel = `downloading ${url} into ${folderPath}`;
+  console.log(timerLabel);
+  console.time(timerLabel);
+
   const parsedUrl = new URL(url);
   // extract domain name from subdomain
   const [extension, domain] = parsedUrl.hostname.split('.').reverse();
@@ -113,10 +139,17 @@ export const downloadUrl = async (
   } catch (e: any) {
     console.error(e.toString());
     fse.removeSync(folderPath);
-    return { status: 'ko', error: e.toString() };
+    throw e;
   }
 
-  fse.writeFileSync(snapshotFilePath, data.snapshot);
+  if (snapshot.mimeType === 'application/pdf') {
+    fse.ensureFileSync(snapshotPDFFilePath);
+    fse.writeFileSync(snapshotPDFFilePath, snapshot.content);
+    return { isPDF: true, url: newPDFUrl };
+  }
+
+  fse.ensureFileSync(indexFilePath);
+  fse.writeFileSync(snapshotFilePath, snapshot.content);
   const browser: Browser = await launchBrowser();
 
   const page = await browser.newPage();
@@ -186,7 +219,6 @@ export const downloadUrl = async (
     assets.push({ from: response.url(), to: `${rewrittenUrl}` });
   });
 
-  let message: any;
   try {
     // Needed because setContent does not wait for resource to be loaded
     // https://github.com/puppeteer/puppeteer/issues/728#issuecomment-524884442
@@ -205,17 +237,16 @@ export const downloadUrl = async (
     const html = await page.content();
 
     fse.writeFileSync(indexFilePath, cleanHtml(html, assets));
-
-    message = { status: 'ok' };
   } catch (e: any) {
     console.error(e.toString());
     fse.removeSync(folderPath);
-    message = { status: 'ko', error: e.toString() };
+    throw e;
   }
 
   await page.close();
 
   await stopBrowser();
 
-  return message;
+  console.timeEnd(timerLabel);
+  return { url: newUrl };
 };

--- a/src/pages/api/services/index.ts
+++ b/src/pages/api/services/index.ts
@@ -7,7 +7,6 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import HttpStatusCode from 'http-status-codes';
 import { addService } from '../../../modules/Contribute/managers/ServiceManager';
-import axios from 'axios';
 import dayjs from 'dayjs';
 import { downloadUrl } from 'modules/Scraper/utils/downloader';
 import fs from 'fs';
@@ -19,29 +18,10 @@ const { serverRuntimeConfig } = getConfig();
 
 const cleanStringForFileSystem = (string: string) => string.replace(/[^\p{L}\d_]/gimu, '_');
 
-const isPdf = async (url: string) => {
-  try {
-    const response = await axios.head(url, { timeout: 3000 });
-    return response.headers['content-type'] === 'application/pdf';
-  } catch (e) {
-    return false;
-  }
-};
-
 const get =
   (json: any, acceptLanguage: string = 'en') =>
   async (_: NextApiRequest, res: NextApiResponse<GetContributeServiceResponse>) => {
     const url = json.fetch;
-
-    if (await isPdf(url)) {
-      res.json({
-        status: 'ok',
-        message: 'OK',
-        url,
-        isPdf: true,
-      });
-      return res;
-    }
 
     // In case executeClientScripts is true, ota snapshot fetcher will wait
     // for selector to be found on the page, so resulting snapshot will be
@@ -63,42 +43,21 @@ const get =
       serverRuntimeConfig.scrapedIframeUrl
     }/${folderName}`;
 
-    const newUrl = `${newUrlPath}/index.html`;
-
-    if (fs.existsSync(folderPath)) {
-      console.log(`Folder ${folderPath} exists`);
-      res.statusCode = HttpStatusCode.OK;
-      res.json({
-        status: 'ok',
-        message: 'OK',
-        url: newUrl,
-      });
-      return res;
-    }
-
     try {
-      console.log(`Folder ${folderPath} does not exist`);
-      console.log(`downloading ${url}`);
-      console.time('downloading');
-      const { error } = await downloadUrl(json, { folderPath, newUrlPath, acceptLanguage });
-      console.timeEnd('downloading');
+      const downloadResult = await downloadUrl(json, {
+        folderPath,
+        newUrlPath,
+        acceptLanguage,
+      });
 
-      if (error) {
-        res.statusCode = HttpStatusCode.OK;
-        res.json({
-          status: 'ko',
-          message: 'Could not download url',
-          url: '',
-          error,
-        });
-        return res;
-      }
+      const { url: newUrl, isPDF } = downloadResult;
 
       res.statusCode = HttpStatusCode.OK;
       res.json({
         status: 'ok',
         message: 'OK',
         url: newUrl,
+        isPDF,
       });
       return res;
     } catch (e: any) {

--- a/src/pages/api/services/index.ts
+++ b/src/pages/api/services/index.ts
@@ -103,7 +103,7 @@ const get =
       return res;
     } catch (e: any) {
       console.error(e);
-      res.statusCode = HttpStatusCode.METHOD_FAILURE;
+      res.statusCode = HttpStatusCode.OK;
       res.json({
         status: 'ko',
         message: 'Could not download url',

--- a/src/pages/api/services/verify.ts
+++ b/src/pages/api/services/verify.ts
@@ -3,10 +3,10 @@ import { GetServiceVerifyResponse } from 'modules/Common/interfaces';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import HttpStatusCode from 'http-status-codes';
-import { getVersion } from 'modules/Common/services/open-terms-archive';
+import { getVersion, OTAJson } from 'modules/Common/services/open-terms-archive';
 
 const get =
-  (json: any, acceptLanguage: string = 'en') =>
+  (json: OTAJson, acceptLanguage: string = 'en') =>
   async (_: NextApiRequest, res: NextApiResponse<GetServiceVerifyResponse>) => {
     try {
       const data = await getVersion(Object.values(json.documents)[0], { language: acceptLanguage });

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -91,8 +91,6 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     },
   };
 
-  const [isPdf, toggleIsPdf] = useToggle(/\.pdf$/gi.test(url));
-
   const [selectable, toggleSelectable] = React.useState('');
   const [iframeReady, toggleIframeReady] = useToggle(false);
   const [loading, toggleLoading] = useToggle(false);
@@ -122,20 +120,26 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     apiUrlParams = `${apiUrlParams}&acceptLanguage=${encodeURIComponent(acceptLanguage)}`;
   }
 
-  const shouldNotRefetchDocument = isPdf || !documentDeclaration.fetch;
+  const shouldNotFetchDocument = !documentDeclaration.fetch;
   const apiUrl = `/api/services?${apiUrlParams}`;
 
-  const { data } = useSWR<GetContributeServiceResponse>(shouldNotRefetchDocument ? null : apiUrl, {
-    revalidateOnMount: true,
-    revalidateIfStale: false,
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false,
-  });
+  const { data, error: apiError } = useSWR<GetContributeServiceResponse>(
+    shouldNotFetchDocument ? null : apiUrl,
+    {
+      revalidateOnMount: true,
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
 
   if (!url) {
     return null;
   }
 
+  const isPDF = data?.isPDF;
+  const submitDisabled = (!initialSignificantCss && !isPDF) || (!iframeReady && !isPDF) || loading;
+  const isLoadingIframe = !data && !apiError;
   const error = data?.error || apiError?.toString();
 
   const selectInIframe = (queryparam: CssRuleChange) => () => {
@@ -308,15 +312,11 @@ Thank you very much`;
     });
   };
 
-  const submitDisabled = (!initialSignificantCss && !isPdf) || (!iframeReady && !isPdf) || loading;
-  const isLoadingIframe = !data && !isPdf;
-
   React.useEffect(() => {
-    if (!!data?.isPdf) {
-      toggleIsPdf(true);
+    if (!!isPDF) {
       removeQueryParams([hiddenCssClass, insignificantCssClass, significantCssClass]);
     }
-  }, [data?.isPdf, removeQueryParams]);
+  }, [isPDF, removeQueryParams]);
 
   React.useEffect(() => {
     if (data?.url !== url) {
@@ -372,7 +372,7 @@ Thank you very much`;
                   <label>{t('service:form.serviceName')}</label>
                   <input defaultValue={initialName} onChange={onInputChange('name')} />
                 </div>
-                {!isPdf && (
+                {!isPDF && (
                   <>
                     <div className={classNames('formfield')}>
                       <label>{t('service:form.significantPart')}</label>
@@ -458,11 +458,11 @@ Thank you very much`;
                           type="checkbox"
                           defaultChecked={!!executeClientScripts}
                           onChange={onCheckboxChange('executeClientScripts')}
-                          disabled={isPdf}
+                          disabled={isPDF}
                         />
                       </div>
                     </div>
-                    {!isPdf && (
+                    {!isPDF && (
                       <div className={classNames('formfield')}>
                         <label>{t('service:form.hiddenPart')}</label>
                         <small className={s.moreinfo}>{t('service:form.hiddenPart.more')}</small>
@@ -527,7 +527,7 @@ Thank you very much`;
           </div>
 
           <div className={s.formBottom}>
-            {!executeClientScripts && iframeReady && !isPdf && (
+            {!executeClientScripts && iframeReady && !isPDF && (
               <div
                 className={classNames(s.formInfos, 'text__light', 'text__error', 'text__center')}
               >
@@ -576,13 +576,13 @@ Thank you very much`;
             </button>
           </div>
         )}
-        {!isLoadingIframe && !data?.error && isPdf && (
-          <iframe src={url} width="100%" style={{ height: '100vh' }} />
+        {!isLoadingIframe && !error && data?.url && isPDF && (
+          <iframe src={data?.url} width="100%" style={{ height: '100vh' }} />
         )}
-        {!isLoadingIframe && !data?.error && !isPdf && (
+        {!isLoadingIframe && !error && data?.url && !isPDF && (
           <IframeSelector
             selectable={!!selectable}
-            url={isPdf ? url : data?.url}
+            url={data?.url}
             selected={significantCss}
             removed={insignificantCss}
             hidden={hiddenCss}

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -136,6 +136,8 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     return null;
   }
 
+  const error = data?.error || apiError?.toString();
+
   const selectInIframe = (queryparam: CssRuleChange) => () => {
     toggleSelectable(queryparam);
   };
@@ -285,7 +287,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
 I need you to track "${initialDocumentType}" of "${initialName}" for me but I had a failure with.
 
 -----
-${data?.error}
+${error}
 -----
 
 Here is the url ${window.location.href}&expertMode=true
@@ -559,10 +561,10 @@ Thank you very much`;
             <Loading />
           </div>
         )}
-        {!isLoadingIframe && data?.error && (
+        {!isLoadingIframe && error && (
           <div className={s.fullPage}>
             <h1>{t('service:error.title')}</h1>
-            <p>{data?.error}</p>
+            <p>{error}</p>
             <Button onClick={onErrorClick}>{t('service:error.cta')}</Button>
           </div>
         )}


### PR DESCRIPTION
Before the use of ota package to get back the snapshot and version, a custom case was made for pdf files, as they did not need the whole process of downloading and selecting.

As we want to harmonize the behaviour between the contribution tool and the ota downloader, we will change that in this PR

Fixes #69 