### PR TITLE
Interpolate service name and document name in PR description

### DIFF
--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -48,9 +48,9 @@ export const addService = async ({
 
   const checkBoxes = [
     '- [ ] **The suggested document matches the scope of this instance**: it targets a service in the language, jurisdiction, and industry that are part of those [described](../#scope) for this instance.',
-    '- [ ] **The service name matches what you see on the web page**, and it complies with the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-name).',
+    `- [ ] **The service name \`${name}\` matches what you see on the web page**, and it complies with the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-name).`,
     `- [ ] **The service ID \`${id}\` (i.e. the name of the file) is derived from the service name** according to the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-id).`,
-    '- [ ] The document type is appropriate for this document: if you read out loud the [document type tryptich](https://github.com/ambanum/OpenTermsArchive/blob/main/src/archivist/services/documentTypes.json), you can say that **“this document describes how the `writer` commits to handle the `object` for its `audience`”**.',
+    `- [ ] The document type \`${documentType}\` is appropriate for this document: if you read out loud the [document type tryptich](https://github.com/ambanum/OpenTermsArchive/blob/main/src/archivist/services/documentTypes.json), you can say that **“this document describes how the \`writer\` commits to handle the \`object\` for its \`audience\`”**.`,
     ...selectorsCheckBoxes,
     '- [ ] **The document content is relevant**: it is not just a series of links, for example.',
     '- [ ] **The generated version is readable**: it is complete and not mangled.',

--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -57,15 +57,15 @@ export const addService = async ({
     '- [ ] **The generated version is clean**: it does not contain navigation links, unnecessary images, or extra content.',
   ];
 
-  const body = `This suggestion has been created with the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can see this declaration suggestion [online](${url}) or [on your local instance](${localUrl}) if you have one set up.
+  const body = `This suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can see this declaration suggestion [online](${url}) or [on your local instance](${localUrl}) if you have one set up.
   
-Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, here are the things you should check:
+Bots should take care of checking the formatting and the validity of the declaration. As a human reviewer, you should check:
 
 ${checkBoxes.join('\n')}
 
-If there seems to be no appropriate document type for this document yet it is relevant to track for this instance, please check if there is already an [open discussion](https://github.com/ambanum/OpenTermsArchive/discussions) about such a type and reference your case there, or open a new discussion if not.
+If no document type seems appropriate for this document yet it is relevant to track in this instance, please check if there is already an [open discussion](https://github.com/ambanum/OpenTermsArchive/discussions) about such a type and reference your case there, or open a new discussion if not.
 
-Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 👏💪
+Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 💪
 `;
 
   return createPullRequest({

--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -49,7 +49,7 @@ export const addService = async ({
   const checkBoxes = [
     '- [ ] **The suggested document matches the scope of this instance**: it targets a service in the language, jurisdiction, and industry that are part of those [described](../#scope) for this instance.',
     '- [ ] **The service name matches what you see on the web page**, and it complies with the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-name).',
-    `- [ ] **The service ID \`${id}\`(i.e. the name of the file) is derived from the service name** according to the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-id).`,
+    `- [ ] **The service ID \`${id}\` (i.e. the name of the file) is derived from the service name** according to the [guidelines](https://github.com/OpenTermsArchive/contrib-declarations/blob/main/CONTRIBUTING.md#service-id).`,
     '- [ ] The document type is appropriate for this document: if you read out loud the [document type tryptich](https://github.com/ambanum/OpenTermsArchive/blob/main/src/archivist/services/documentTypes.json), you can say that **“this document describes how the `writer` commits to handle the `object` for its `audience`”**.',
     ...selectorsCheckBoxes,
     '- [ ] **The document content is relevant**: it is not just a series of links, for example.',


### PR DESCRIPTION
Align behavior with ID and ease review.

Fix whitespace in ID interpolation.