### PR TITLE
Fix missing css

### DIFF
--- a/src/modules/Scraper/utils/downloader.ts
+++ b/src/modules/Scraper/utils/downloader.ts
@@ -152,12 +152,15 @@ export const downloadUrl = async (
     const buffer = await response.buffer();
     let targetPathname = pathname;
     if (resourceType === 'stylesheet' && !pathname.endsWith('.css')) {
-      targetPathname = `${pathname}.css`;
+      // add random string in case url is of type /static/?e=something
+      // initially done for https://unternehmen.geizhals.at/allgemeine-geschaeftsbedingungen/
+      targetPathname = `${pathname}_${Math.random()
+        .toString(36)
+        .replace(/[^a-z]+/g, '')}.css`;
     }
     const existingUrl = `${pathname}${search}`;
     let rewrittenUrl = `${newUrlPath}${targetPathname}`;
     const relativeUrl = existingUrl.replace(parsedUrl.pathname, '');
-
     try {
       fse.outputFileSync(`${folderPath}${targetPathname}`, buffer, 'base64');
     } catch (e: any) {


### PR DESCRIPTION
Sometimes, CSS files loaded by the target page are of type `/static/?e=something`

It means they do not have a file name at all.

This results in having a file named `/static/.css` which is not loadable by a browser.

A first fix had already been made but wad not sufficient to handle all cases and especially this one https://unternehmen.geizhals.at/allgemeine-geschaeftsbedingungen/

Thjs PR fixes this

