### PR TITLE
Start before end before

### DIFF
--- a/src/components/IframeSelector/SelectorButton.tsx
+++ b/src/components/IframeSelector/SelectorButton.tsx
@@ -59,7 +59,7 @@ const SelectorButton: React.FC<SelectorButtonProps> = ({
         onChange(debouncedSelector);
       }
     },
-    500,
+    1500,
     [debouncedSelector]
   );
 

--- a/src/components/IframeSelector/SelectorButton.tsx
+++ b/src/components/IframeSelector/SelectorButton.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Button from 'modules/Common/components/Button';
+import { FiTrash2 } from 'react-icons/fi';
+
+type SelectorButtonProps = {
+  onChange: any;
+  onRemove: any;
+  defaultValue: string;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const SelectorButton: React.FC<SelectorButtonProps> = ({
+  onChange,
+  onRemove,
+  defaultValue,
+  className,
+  ...props
+}) => {
+  return (
+    <div key={defaultValue} className={className} {...props}>
+      <input defaultValue={defaultValue} onChange={onChange} />
+
+      <Button onClick={onRemove} type="secondary" size="sm" onlyIcon={true}>
+        <FiTrash2 />
+      </Button>
+    </div>
+  );
+};
+
+export default SelectorButton;

--- a/src/components/IframeSelector/SelectorButton.tsx
+++ b/src/components/IframeSelector/SelectorButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Button from 'modules/Common/components/Button';
+import { useDebounce } from 'react-use';
 import { FiTrash2 as RemoveIcon, FiRepeat as SwitchIcon } from 'react-icons/fi';
 
 type SelectorButtonProps = {
@@ -33,14 +34,27 @@ const SelectorButton: React.FC<SelectorButtonProps> = ({
   }
 
   const [selector, setSelector] = React.useState<InputValue>(selectorValue);
+  const [debouncedSelector, setDebouncedSelector] = React.useState<string>();
   const isRangeObject = typeof selector === 'object';
 
   const updateSelector = React.useCallback(
     (newSelector: InputValue) => {
       setSelector(newSelector);
-      onChange(typeof newSelector === 'object' ? JSON.stringify(newSelector) : newSelector);
+      setDebouncedSelector(
+        typeof newSelector === 'object' ? JSON.stringify(newSelector) : newSelector
+      );
     },
     [isRangeObject]
+  );
+
+  useDebounce(
+    () => {
+      if (debouncedSelector) {
+        onChange(debouncedSelector);
+      }
+    },
+    500,
+    [debouncedSelector]
   );
 
   const onSwitch = () => {

--- a/src/components/IframeSelector/SelectorButton.tsx
+++ b/src/components/IframeSelector/SelectorButton.tsx
@@ -1,26 +1,127 @@
 import React from 'react';
 import Button from 'modules/Common/components/Button';
-import { FiTrash2 } from 'react-icons/fi';
+import { FiTrash2 as RemoveIcon, FiRepeat as SwitchIcon } from 'react-icons/fi';
 
 type SelectorButtonProps = {
   onChange: any;
-  onRemove: any;
-  defaultValue: string;
+  onRemove?: any;
+  value: string;
 } & React.HTMLAttributes<HTMLDivElement>;
+
+interface RangeSelector {
+  startBefore?: string;
+  endBefore?: string;
+  startAfter?: string;
+  endAfter?: string;
+}
+
+type InputValue = string | RangeSelector;
 
 const SelectorButton: React.FC<SelectorButtonProps> = ({
   onChange,
   onRemove,
-  defaultValue,
+  value,
   className,
   ...props
 }) => {
-  return (
-    <div key={defaultValue} className={className} {...props}>
-      <input defaultValue={defaultValue} onChange={onChange} />
+  let selectorValue: InputValue;
 
-      <Button onClick={onRemove} type="secondary" size="sm" onlyIcon={true}>
-        <FiTrash2 />
+  try {
+    selectorValue = JSON.parse(value) as RangeSelector;
+  } catch (e) {
+    selectorValue = value as string;
+  }
+
+  const [selector, setSelector] = React.useState<InputValue>(selectorValue);
+  const isRangeObject = typeof selector === 'object';
+
+  const updateSelector = React.useCallback(
+    (newSelector: InputValue) => {
+      setSelector(newSelector);
+      onChange(typeof newSelector === 'object' ? JSON.stringify(newSelector) : newSelector);
+    },
+    [isRangeObject]
+  );
+
+  const onSwitch = () => {
+    if (isRangeObject) {
+      const newSelector: string = (selector as any)[
+        Object.keys(selector as any).filter(Boolean)[0] || 'startBefore'
+      ];
+      updateSelector(newSelector);
+    } else {
+      updateSelector({ startBefore: selector });
+    }
+  };
+
+  const onObjectChange = React.useCallback(
+    (key: keyof RangeSelector) => (e: any) => {
+      const newSelector = e.target.value;
+      const newObject = { ...(selector as RangeSelector) };
+
+      if (newSelector) {
+        newObject[key] = newSelector;
+      } else {
+        delete newObject[key];
+      }
+      updateSelector(newObject);
+    },
+    [selector, updateSelector]
+  );
+
+  return (
+    <div key={value} className={className} {...props}>
+      {!isRangeObject && <input defaultValue={selector} onInput={onChange} />}
+      {isRangeObject && (
+        <table>
+          <tr>
+            <td>startBefore</td>
+            <td>
+              <input
+                defaultValue={selector?.startBefore}
+                onInput={onObjectChange('startBefore')}
+                disabled={!!selector?.startAfter}
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>startAfter</td>
+            <td>
+              <input
+                defaultValue={selector?.startAfter}
+                onInput={onObjectChange('startAfter')}
+                disabled={!!selector?.startBefore}
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>endBefore</td>
+            <td>
+              <input
+                defaultValue={selector?.endBefore}
+                onInput={onObjectChange('endBefore')}
+                disabled={!!selector?.endAfter}
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>endAfter</td>
+            <td>
+              <input
+                defaultValue={selector?.endAfter}
+                onInput={onObjectChange('endAfter')}
+                disabled={!!selector?.endBefore}
+              />
+            </td>
+          </tr>
+        </table>
+      )}
+
+      <Button onClick={onSwitch} size="sm" onlyIcon={true}>
+        <SwitchIcon />
+      </Button>
+      <Button onClick={onRemove} type="secondary" color="red" size="sm" onlyIcon={true}>
+        <RemoveIcon />
       </Button>
     </div>
   );

--- a/src/components/IframeSelector/SelectorButton.tsx
+++ b/src/components/IframeSelector/SelectorButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from 'modules/Common/components/Button';
-import { useDebounce } from 'react-use';
+import { useDebounce, useLocalStorage } from 'react-use';
 import { FiTrash2 as RemoveIcon, FiRepeat as SwitchIcon } from 'react-icons/fi';
 
 type SelectorButtonProps = {
@@ -28,6 +28,10 @@ const SelectorButton: React.FC<SelectorButtonProps> = ({
   ...props
 }) => {
   let selectorValue: InputValue;
+  const [alertViewed, setAlertViewed] = useLocalStorage<boolean>(
+    'sc-startBefore-experiment-viewed',
+    false
+  );
 
   try {
     selectorValue = JSON.parse(value) as RangeSelector;
@@ -86,62 +90,72 @@ const SelectorButton: React.FC<SelectorButtonProps> = ({
   );
 
   return (
-    <div key={value} className={className} {...props}>
-      {!isRangeObject && <input defaultValue={selector} onInput={onChange} />}
-      {isRangeObject && (
-        <table>
-          <tr>
-            <td>startBefore</td>
-            <td>
-              <input
-                defaultValue={selector?.startBefore}
-                onInput={onObjectChange('startBefore')}
-                disabled={!!selector?.startAfter}
-              />
-            </td>
-          </tr>
-          <tr>
-            <td>startAfter</td>
-            <td>
-              <input
-                defaultValue={selector?.startAfter}
-                onInput={onObjectChange('startAfter')}
-                disabled={!!selector?.startBefore}
-              />
-            </td>
-          </tr>
-          <tr>
-            <td>endBefore</td>
-            <td>
-              <input
-                defaultValue={selector?.endBefore}
-                onInput={onObjectChange('endBefore')}
-                disabled={!!selector?.endAfter}
-              />
-            </td>
-          </tr>
-          <tr>
-            <td>endAfter</td>
-            <td>
-              <input
-                defaultValue={selector?.endAfter}
-                onInput={onObjectChange('endAfter')}
-                disabled={!!selector?.endBefore}
-              />
-            </td>
-          </tr>
-        </table>
+    <>
+      {withSwitch && isRangeObject && !alertViewed && (
+        <button onClick={() => setAlertViewed(true)}>
+          This feature is experimental, please make sure you know what you're doing.
+          <br />
+          <br />
+          Click to dismiss.
+        </button>
       )}
+      <div key={value} className={className} {...props}>
+        {!isRangeObject && <input defaultValue={selector} onInput={onChange} />}
+        {isRangeObject && (
+          <table>
+            <tr>
+              <td>startBefore</td>
+              <td>
+                <input
+                  defaultValue={selector?.startBefore}
+                  onInput={onObjectChange('startBefore')}
+                  disabled={!!selector?.startAfter}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>startAfter</td>
+              <td>
+                <input
+                  defaultValue={selector?.startAfter}
+                  onInput={onObjectChange('startAfter')}
+                  disabled={!!selector?.startBefore}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>endBefore</td>
+              <td>
+                <input
+                  defaultValue={selector?.endBefore}
+                  onInput={onObjectChange('endBefore')}
+                  disabled={!!selector?.endAfter}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>endAfter</td>
+              <td>
+                <input
+                  defaultValue={selector?.endAfter}
+                  onInput={onObjectChange('endAfter')}
+                  disabled={!!selector?.endBefore}
+                />
+              </td>
+            </tr>
+          </table>
+        )}
 
-      {withSwitch && (
-        <Button onClick={onSwitch} size="sm" onlyIcon={true}>
-          <SwitchIcon />
+        {withSwitch && (
+          <Button onClick={onSwitch} size="sm" onlyIcon={true}>
+            <SwitchIcon />
+          </Button>
+        )}
+        <Button onClick={onRemove} type="secondary" color="red" size="sm" onlyIcon={true}>
+          <RemoveIcon />
         </Button>
-      )}
-      <Button onClick={onRemove} type="secondary" color="red" size="sm" onlyIcon={true}>
-        <RemoveIcon />
-      </Button>
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/src/components/IframeSelector/SelectorButton.tsx
+++ b/src/components/IframeSelector/SelectorButton.tsx
@@ -7,6 +7,7 @@ type SelectorButtonProps = {
   onChange: any;
   onRemove?: any;
   value: string;
+  withSwitch?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 interface RangeSelector {
@@ -23,6 +24,7 @@ const SelectorButton: React.FC<SelectorButtonProps> = ({
   onRemove,
   value,
   className,
+  withSwitch = true,
   ...props
 }) => {
   let selectorValue: InputValue;
@@ -131,9 +133,11 @@ const SelectorButton: React.FC<SelectorButtonProps> = ({
         </table>
       )}
 
-      <Button onClick={onSwitch} size="sm" onlyIcon={true}>
-        <SwitchIcon />
-      </Button>
+      {withSwitch && (
+        <Button onClick={onSwitch} size="sm" onlyIcon={true}>
+          <SwitchIcon />
+        </Button>
+      )}
       <Button onClick={onRemove} type="secondary" color="red" size="sm" onlyIcon={true}>
         <RemoveIcon />
       </Button>

--- a/src/components/IframeSelector/SelectorButton.tsx
+++ b/src/components/IframeSelector/SelectorButton.tsx
@@ -100,7 +100,12 @@ const SelectorButton: React.FC<SelectorButtonProps> = ({
         </button>
       )}
       <div key={value} className={className} {...props}>
-        {!isRangeObject && <input defaultValue={selector} onInput={onChange} />}
+        {!isRangeObject && (
+          <input
+            defaultValue={selector}
+            onInput={(e: any) => setDebouncedSelector(e.target.value)}
+          />
+        )}
         {isRangeObject && (
           <table>
             <tr>

--- a/src/components/IframeSelector/index.tsx
+++ b/src/components/IframeSelector/index.tsx
@@ -93,11 +93,11 @@ const generateBeforeAfterCSS = (
 
   return cssSelectors.length > 0
     ? `
-    ${selectors} { border: 2px solid ${color}; min-width: 150px; }
+    ${selectors} { border: 2px solid ${color}; min-width: 150px; position:relative; }
     ${pseudoSelectors} { 
       content: "";
       position: absolute;
-      min-width: 150px;
+      min-width: 80px;
       left: 0;
       right: 0;
       margin: 0 auto;

--- a/src/modules/Common/styles/elements/form.css
+++ b/src/modules/Common/styles/elements/form.css
@@ -21,6 +21,11 @@ input:is([disabled]):not([type='submit']) textarea:disabled {
   background-color: var(--colorBlack400);
 }
 
+input[disabled] {
+  background-color: var(--colorBlack200);
+  cursor: not-allowed;
+}
+
 input[type='checkbox'] {
   width: 2rem;
   height: 2rem;

--- a/src/pages/service.module.css
+++ b/src/pages/service.module.css
@@ -81,7 +81,7 @@
 }
 
 .formActions {
-  border-top: 1px solid var(--colorBlack200);
+  border-top: 1px solid var(--colorBlack400);
   padding-top: var(--mM);
   display: flex;
   justify-content: flex-end;
@@ -107,8 +107,15 @@
 
 .selectionItem {
   display: flex;
-  align-items: flex-start;
-  margin-bottom: var(--mXS);
+  align-items: center;
+  padding: var(--mXS) 0;
+  margin: 0;
+  border-top: 1px solid var(--colorBlack200);
+
+  & table {
+    flex: 1;
+    border-spacing: 0px var(--3mXS);
+  }
 
   & > button {
     margin-left: var(--mS);

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -170,8 +170,9 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     [url, hiddenCss, insignificantCss, significantCss, pushQueryParam, selectable, toggleSelectable]
   );
 
-  const onChangeCssRule = (queryparam: CssRuleChange, index: number) => (e: any) => {
-    const value = e.target?.value;
+  const onChangeCssRule = (queryparam: CssRuleChange, index: number) => (valueOrEvent: any) => {
+    const value = valueOrEvent.target?.value || valueOrEvent;
+
     if (!value) {
       onRemoveCssRule(queryparam, index)();
       return;
@@ -381,7 +382,7 @@ Thank you very much`;
                         <SelectorButton
                           className={s.selectionItem}
                           key={selected}
-                          defaultValue={selected}
+                          value={selected}
                           onChange={onChangeCssRule(significantCssClass, i)}
                           onRemove={onRemoveCssRule(significantCssClass, i)}
                         />
@@ -404,7 +405,7 @@ Thank you very much`;
                           <SelectorButton
                             className={s.selectionItem}
                             key={selected}
-                            defaultValue={selected}
+                            value={selected}
                             onChange={onChangeCssRule(insignificantCssClass, i)}
                             onRemove={onRemoveCssRule(insignificantCssClass, i)}
                           />
@@ -455,7 +456,7 @@ Thank you very much`;
                           <SelectorButton
                             className={s.selectionItem}
                             key={hidden}
-                            defaultValue={hidden}
+                            value={hidden}
                             onChange={onChangeCssRule(hiddenCssClass, i)}
                             onRemove={onRemoveCssRule(hiddenCssClass, i)}
                           />

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -79,14 +79,17 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     // This is here as previously created issues still point at a url that has no `destination` param
     pushQueryParam('destination')('OpenTermsArchive/contrib-declarations');
   }
-
   const json = {
     name: initialName || '???',
     documents: {
       [initialDocumentType || '???']: {
         fetch: url,
-        select: initialSignificantCss,
-        remove: initialInsignificantCss,
+        select: initialSignificantCss?.map((css: any) =>
+          css.startsWith('{') ? JSON.parse(css) : css
+        ),
+        remove: initialInsignificantCss?.map((css: any) =>
+          css.startsWith('{') ? JSON.parse(css) : css
+        ),
         ...(executeClientScripts ? { executeClientScripts: true } : {}),
       },
     },

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -459,6 +459,7 @@ Thank you very much`;
                             value={hidden}
                             onChange={onChangeCssRule(hiddenCssClass, i)}
                             onRemove={onRemoveCssRule(hiddenCssClass, i)}
+                            withSwitch={false}
                           />
                         ))}
                         <Button

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -1,4 +1,4 @@
-import { FiChevronDown, FiChevronUp, FiTrash2 } from 'react-icons/fi';
+import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
 import {
   GetContributeServiceResponse,
   PostContributeServiceResponse,
@@ -10,6 +10,7 @@ import Button from 'modules/Common/components/Button';
 import Drawer from 'components/Drawer';
 import { FiAlertTriangle as IconAlert } from 'react-icons/fi';
 import IframeSelector from 'components/IframeSelector';
+import SelectorButton from 'components/IframeSelector/SelectorButton';
 import LinkIcon from 'modules/Common/components/LinkIcon';
 import Loading from 'components/Loading';
 import React from 'react';
@@ -377,21 +378,13 @@ Thank you very much`;
                     <div className={classNames('formfield')}>
                       <label>{t('service:form.significantPart')}</label>
                       {significantCss.map((selected, i) => (
-                        <div key={selected} className={s.selectionItem}>
-                          <input
-                            defaultValue={selected}
-                            onChange={onChangeCssRule(significantCssClass, i)}
-                          />
-
-                          <Button
-                            onClick={onRemoveCssRule(significantCssClass, i)}
-                            type="secondary"
-                            size="sm"
-                            onlyIcon={true}
-                          >
-                            <FiTrash2></FiTrash2>
-                          </Button>
-                        </div>
+                        <SelectorButton
+                          className={s.selectionItem}
+                          key={selected}
+                          defaultValue={selected}
+                          onChange={onChangeCssRule(significantCssClass, i)}
+                          onRemove={onRemoveCssRule(significantCssClass, i)}
+                        />
                       ))}
                       <Button
                         onClick={selectInIframe(significantCssClass)}
@@ -408,21 +401,13 @@ Thank you very much`;
                         <label>{t('service:form.insignificantPart')}</label>
 
                         {insignificantCss.map((selected, i) => (
-                          <div key={selected} className={s.selectionItem}>
-                            <input
-                              defaultValue={selected}
-                              onChange={onChangeCssRule(insignificantCssClass, i)}
-                            />
-
-                            <Button
-                              onClick={onRemoveCssRule(insignificantCssClass, i)}
-                              type="secondary"
-                              size="sm"
-                              onlyIcon={true}
-                            >
-                              <FiTrash2></FiTrash2>
-                            </Button>
-                          </div>
+                          <SelectorButton
+                            className={s.selectionItem}
+                            key={selected}
+                            defaultValue={selected}
+                            onChange={onChangeCssRule(insignificantCssClass, i)}
+                            onRemove={onRemoveCssRule(insignificantCssClass, i)}
+                          />
                         ))}
                         <Button
                           onClick={selectInIframe(insignificantCssClass)}
@@ -467,21 +452,13 @@ Thank you very much`;
                         <label>{t('service:form.hiddenPart')}</label>
                         <small className={s.moreinfo}>{t('service:form.hiddenPart.more')}</small>
                         {hiddenCss.map((hidden, i) => (
-                          <div key={hidden} className={s.selectionItem}>
-                            <input
-                              defaultValue={hidden}
-                              onChange={onChangeCssRule(hiddenCssClass, i)}
-                            />
-
-                            <Button
-                              onClick={onRemoveCssRule(hiddenCssClass, i)}
-                              type="secondary"
-                              size="sm"
-                              onlyIcon={true}
-                            >
-                              <FiTrash2></FiTrash2>
-                            </Button>
-                          </div>
+                          <SelectorButton
+                            className={s.selectionItem}
+                            key={hidden}
+                            defaultValue={hidden}
+                            onChange={onChangeCssRule(hiddenCssClass, i)}
+                            onRemove={onRemoveCssRule(hiddenCssClass, i)}
+                          />
                         ))}
                         <Button
                           onClick={selectInIframe(hiddenCssClass)}

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -79,21 +79,6 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     // This is here as previously created issues still point at a url that has no `destination` param
     pushQueryParam('destination')('OpenTermsArchive/contrib-declarations');
   }
-  const json = {
-    name: initialName || '???',
-    documents: {
-      [initialDocumentType || '???']: {
-        fetch: url,
-        select: initialSignificantCss?.map((css: any) =>
-          css.startsWith('{') ? JSON.parse(css) : css
-        ),
-        remove: initialInsignificantCss?.map((css: any) =>
-          css.startsWith('{') ? JSON.parse(css) : css
-        ),
-        ...(executeClientScripts ? { executeClientScripts: true } : {}),
-      },
-    },
-  };
 
   const [selectable, toggleSelectable] = React.useState('');
   const [iframeReady, toggleIframeReady] = useToggle(false);
@@ -116,6 +101,24 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     : Array.isArray(initialHiddenCss)
     ? initialHiddenCss
     : [initialHiddenCss];
+
+  const json = {
+    name: initialName || '???',
+    documents: {
+      [initialDocumentType || '???']: {
+        fetch: url,
+        select:
+          significantCss.length > 0
+            ? significantCss.map((css: any) => (css.startsWith('{') ? JSON.parse(css) : css))
+            : undefined,
+        remove:
+          insignificantCss.length > 0
+            ? insignificantCss.map((css: any) => (css.startsWith('{') ? JSON.parse(css) : css))
+            : undefined,
+        ...(executeClientScripts ? { executeClientScripts: true } : {}),
+      },
+    },
+  };
 
   const documentDeclaration = Object.values(json.documents)[0];
   let apiUrlParams = `json=${encodeURIComponent(JSON.stringify(documentDeclaration))}`;


### PR DESCRIPTION
Sometimes, and especially on [twitter terms](https://twitter.com/en/tos#intlTerms), area to select has to be done with `startBefore`, `endBefore`, `startAfter` and `endAfter`.

This PR brings this functionality in an experimental format.

This means that a user can switch from the normal selector to this custom selector, but he will have to paste the selectors directly in the input fields.

This feature would need a more heavy UX.

Here is an example of how it would look like with an `endAfter` `footer`
![Screen Shot 2022-08-15 at 17 36 01](https://user-images.githubusercontent.com/4191809/184645590-45038bd5-39f6-4fe3-86ad-2afed2b831eb.png)
 refactor to be useable by end user so I decided to ship it that way

 