### PR TITLE
Add Tryptich display when changing document type

### DIFF
--- a/src/modules/Common/styles/elements/definition-lists.css
+++ b/src/modules/Common/styles/elements/definition-lists.css
@@ -1,0 +1,21 @@
+dl {
+  display: flex;
+  flex-flow: row wrap;
+  border: solid var(--colorBlack400);
+  border-width: 1px 1px 0 0;
+}
+dt {
+  flex-basis: 25%;
+  padding: 2px 4px;
+  background: var(--colorBlack800);
+  text-align: right;
+  color: var(--colorBlack200);
+  border-bottom: 1px solid var(--colorBlack400);
+}
+dd {
+  flex-basis: 70%;
+  flex-grow: 1;
+  margin: 0;
+  padding: 2px 4px;
+  border-bottom: 1px solid var(--colorBlack400);
+}

--- a/src/modules/Common/styles/elements/definition-lists.css
+++ b/src/modules/Common/styles/elements/definition-lists.css
@@ -2,20 +2,21 @@ dl {
   display: flex;
   flex-flow: row wrap;
   border: solid var(--colorBlack400);
-  border-width: 1px 1px 0 0;
+  border-width: 0px 1px 0 1px;
+  font-size: 1.4rem;
+  background: var(--colorBlack200);
 }
 dt {
   flex-basis: 25%;
   padding: 2px 4px;
-  background: var(--colorBlack800);
   text-align: right;
-  color: var(--colorBlack200);
   border-bottom: 1px solid var(--colorBlack400);
+  border-right: 1px solid var(--colorBlack400);
 }
 dd {
   flex-basis: 70%;
   flex-grow: 1;
   margin: 0;
   padding: 2px 4px;
-  border-bottom: 1px solid var(--colorBlack400);
+  border-bottom: 1px solid var(--colorBlack600);
 }

--- a/src/modules/Common/styles/loader.css
+++ b/src/modules/Common/styles/loader.css
@@ -23,3 +23,4 @@
 @import 'elements/links.css';
 @import 'elements/form.css';
 @import 'elements/blockquote.css';
+@import 'elements/definition-lists.css';

--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -25,13 +25,23 @@ export interface Commit {
 
 export type Commits = Commit[];
 
-export const getDocumentTypes: any = async () => {
+export interface DocumentTypes {
+  [key: string]: {
+    commitment: {
+      writer: string;
+      audience: string;
+      object: string;
+    };
+  };
+}
+
+export const getDocumentTypes = async () => {
   try {
-    const { data: documentTypes } = await axios.get(DOCUMENT_TYPES_URL);
-    return [...new Set(Object.keys(documentTypes))].sort();
+    const { data: documentTypes } = await axios.get<DocumentTypes>(DOCUMENT_TYPES_URL);
+    return documentTypes;
   } catch (e) {
     console.error(e);
-    return [];
+    return {};
   }
 };
 

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -5,7 +5,7 @@ import { i18n } from '../../next.config';
 const PUBLIC_FILE = /\.([a-zA-Z]+$)/;
 
 export function middleware(request: NextRequest) {
-  const { pathname, search, locale } = request.nextUrl;
+  const { pathname, search, locale, origin } = request.nextUrl;
 
   if (pathname.includes('/api/') || pathname.includes('/fonts/')) {
     return;
@@ -16,5 +16,7 @@ export function middleware(request: NextRequest) {
   acceptLanguage.languages(i18n.locales?.filter((locale) => locale !== 'default'));
   const detectedLocale = acceptLanguage.get(request.headers.get('accept-language'));
 
-  return shouldHandleLocale && NextResponse.redirect(`/${detectedLocale}${pathname}${search}`);
+  return (
+    shouldHandleLocale && NextResponse.redirect(`${origin}/${detectedLocale}${pathname}${search}`)
+  );
 }

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -148,6 +148,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
   const submitDisabled = (!initialSignificantCss && !isPDF) || (!iframeReady && !isPDF) || loading;
   const isLoadingIframe = !data && !apiError;
   const error = data?.error || apiError?.toString();
+  const documentTypeCommitment = documentTypes[initialDocumentType]?.commitment;
 
   const selectInIframe = (queryparam: CssRuleChange) => () => {
     toggleSelectable(queryparam);
@@ -376,6 +377,18 @@ Thank you very much`;
                         ))}
                     </select>
                     <FiChevronDown color="333333"></FiChevronDown>
+                    {initialDocumentType && (
+                      <dl>
+                        {Object.entries(documentTypeCommitment).map(
+                          ([tryptichKey, tryptichValue]) => (
+                            <>
+                              <dt>{tryptichKey}</dt>
+                              <dd>{tryptichValue}</dd>
+                            </>
+                          )
+                        )}
+                      </dl>
+                    )}
                   </div>
                 </div>
                 <div className={classNames('formfield')}>

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import api from 'utils/api';
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';
-import { getDocumentTypes } from 'modules/Github/api';
+import { getDocumentTypes, DocumentTypes } from 'modules/Github/api';
 import s from './service.module.css';
 import useNotifier from 'hooks/useNotifier';
 import { useRouter } from 'next/router';
@@ -36,7 +36,7 @@ const insignificantCssClass = 'removedCss';
 const hiddenCssClass = 'hiddenCss';
 type CssRuleChange = 'selectedCss' | 'removedCss' | 'hiddenCss';
 
-const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
+const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
   let [isServiceHelpViewed, setServiceHelpViewed] = useLocalStorage(
     'serviceHelpDialogViewed',
     false
@@ -367,11 +367,13 @@ Thank you very much`;
                       defaultValue={initialDocumentType}
                     >
                       <option value="">{t('service:form.select')}</option>
-                      {documentTypes.map((documentType) => (
-                        <option key={documentType} value={documentType}>
-                          {documentType}
-                        </option>
-                      ))}
+                      {Object.keys(documentTypes)
+                        .sort()
+                        .map((documentType) => (
+                          <option key={documentType} value={documentType}>
+                            {documentType}
+                          </option>
+                        ))}
                     </select>
                     <FiChevronDown color="333333"></FiChevronDown>
                   </div>


### PR DESCRIPTION
Very simple with not much design but useful so that contributors validate the document type they're choosing.
![Screen Shot 2022-08-25 at 14 28 40](https://user-images.githubusercontent.com/4191809/186641902-68e14a32-51f4-499d-986f-b7a6f5830b28.png)

Maybe @clementbiron can propose something better when he comes back
