### PR TITLE
Prevent client to fail when document type is not found

### DIFF
--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -148,7 +148,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
   const submitDisabled = (!initialSignificantCss && !isPDF) || (!iframeReady && !isPDF) || loading;
   const isLoadingIframe = !data && !apiError;
   const error = data?.error || apiError?.toString();
-  const documentTypeCommitment = documentTypes[initialDocumentType]?.commitment;
+  const documentTypeCommitment = documentTypes[initialDocumentType]?.commitment || {};
 
   const selectInIframe = (queryparam: CssRuleChange) => () => {
     toggleSelectable(queryparam);


### PR DESCRIPTION
Example on this [addition](https://contribute.opentermsarchive.org/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&documentType=Marketplace%20Sellers%20Conditions&name=Tori&url=https%3A%2F%2Fschibstedforbusiness.com%2Ffinland%2Fdocuments%2FB2B-yleiset-kayttoehdot.pdf&expertMode=true)

Document Types may not be populated on first request and thus resulting in an undefined tryptic.

This behavior did not happen on local