### PR TITLE
Replace document type URL

### DIFF
--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -1,4 +1,5 @@
-const DOCUMENT_TYPES_URL = 'https://api.opentermsarchive.org/data/api/list_documentTypes/v1/';
+const DOCUMENT_TYPES_URL =
+  'https://raw.githubusercontent.com/ambanum/OpenTermsArchive/main/src/archivist/services/documentTypes.json';
 
 import { Octokit } from 'octokit';
 import axios from 'axios';


### PR DESCRIPTION
In order to not be able to wait for the dataset creation, we link directly to raw GitHub file.

There is a rate limit of 5,000 calls per hour (88 / min) from the same IP Address which is more than enough for our use