### PR TITLE
Dir name too long

### DIFF
--- a/src/modules/Common/services/open-terms-archive.ts
+++ b/src/modules/Common/services/open-terms-archive.ts
@@ -84,7 +84,7 @@ const cleanStringForFileSystem = (string: string) => string.replace(/[^\p{L}\d_]
 // for selector to be found on the page. The resulting snapshot will be
 // different each time a new selector is added.
 // This is the same if language changes
-export const generateAlwaysValidFolderName = (
+export const generateFolderName = (
   { fetch, select, executeClientScripts }: OTADocumentDeclaration,
   additionalParameter?: string
 ) => {

--- a/src/modules/Common/services/open-terms-archive.ts
+++ b/src/modules/Common/services/open-terms-archive.ts
@@ -78,5 +78,33 @@ export const getVersion = async (documentDeclaration: OTADocumentDeclaration, co
   return getVersionFromSnapshot(snapshot);
 };
 
+const cleanStringForFileSystem = (string: string) => string.replace(/[^\p{L}\d_]/gimu, '_');
+
+// In case executeClientScripts is true, ota snapshot fetcher will wait
+// for selector to be found on the page. The resulting snapshot will be
+// different each time a new selector is added.
+// This is the same if language changes
+export const generateAlwaysValidFolderName = (
+  { fetch, select, executeClientScripts }: OTADocumentDeclaration,
+  additionalParameter?: string
+) => {
+  const MAX_FOLDER_CHARACTERS = 256;
+  const urlString = cleanStringForFileSystem(fetch.replace(/http?s:\/\//, ''));
+  const selectString = select
+    ? `_${DocumentDeclaration.extractCssSelectorsFromProperty(select).filter(Boolean)}`
+    : '';
+  const fullDomParameters = executeClientScripts ? `1_${selectString}` : '0';
+  const additionalParameters = additionalParameter || '';
+
+  const downloadParameters = `_${[fullDomParameters, additionalParameters]
+    .filter(Boolean)
+    .map(cleanStringForFileSystem)
+    .join('_')}`;
+
+  const leftCharactersForUrl = MAX_FOLDER_CHARACTERS - downloadParameters.length;
+
+  return `${urlString.substring(0, leftCharactersForUrl - 1)}${downloadParameters}`;
+};
+
 export const launchBrowser = launchHeadlessBrowser;
 export const stopBrowser = stopHeadlessBrowser;

--- a/src/modules/Scraper/utils/downloader.ts
+++ b/src/modules/Scraper/utils/downloader.ts
@@ -8,6 +8,7 @@ import {
 
 import RecaptchaPlugin from 'puppeteer-extra-plugin-recaptcha';
 import debug from 'debug';
+import path from 'path';
 import fse from 'fs-extra';
 import type { Page, Browser } from 'puppeteer'; // from open-terms-archive
 import puppeteer from 'puppeteer-extra'; // from open-terms-archive
@@ -17,6 +18,7 @@ import {
   Snapshot,
   stopBrowser,
   launchBrowser,
+  generateAlwaysValidFolderName,
 } from 'modules/Common/services/open-terms-archive';
 
 puppeteer.use(RecaptchaPlugin());
@@ -105,11 +107,15 @@ type DownloadResult = {
 export const downloadUrl = async (
   json: any,
   {
-    folderPath,
-    newUrlPath,
+    folderDirPath,
+    newUrlDirPath,
     acceptLanguage = 'en',
-  }: { folderPath: string; newUrlPath: string; acceptLanguage?: string }
+  }: { folderDirPath: string; newUrlDirPath: string; acceptLanguage?: string }
 ): Promise<DownloadResult> => {
+  const folderName = generateAlwaysValidFolderName(json, acceptLanguage);
+  const folderPath = path.join(folderDirPath, folderName);
+  const newUrlPath = path.join(newUrlDirPath, folderName);
+
   const url = json.fetch;
   const snapshotFilePath = `${folderPath}/snapshot.html`;
   const indexFilePath = `${folderPath}/index.html`;

--- a/src/modules/Scraper/utils/downloader.ts
+++ b/src/modules/Scraper/utils/downloader.ts
@@ -18,7 +18,7 @@ import {
   Snapshot,
   stopBrowser,
   launchBrowser,
-  generateAlwaysValidFolderName,
+  generateFolderName,
 } from 'modules/Common/services/open-terms-archive';
 
 puppeteer.use(RecaptchaPlugin());
@@ -112,7 +112,7 @@ export const downloadUrl = async (
     acceptLanguage = 'en',
   }: { folderDirPath: string; newUrlDirPath: string; acceptLanguage?: string }
 ): Promise<DownloadResult> => {
-  const folderName = generateAlwaysValidFolderName(json, acceptLanguage);
+  const folderName = generateFolderName(json, acceptLanguage);
   const folderPath = path.join(folderDirPath, folderName);
   const newUrlPath = path.join(newUrlDirPath, folderName);
 

--- a/src/pages/api/services/index.ts
+++ b/src/pages/api/services/index.ts
@@ -12,41 +12,18 @@ import { downloadUrl } from 'modules/Scraper/utils/downloader';
 import fs from 'fs';
 import getConfig from 'next/config';
 import { getLatestCommit } from 'modules/Github/api';
-import path from 'path';
 
 const { serverRuntimeConfig } = getConfig();
-
-const cleanStringForFileSystem = (string: string) => string.replace(/[^\p{L}\d_]/gimu, '_');
 
 const get =
   (json: any, acceptLanguage: string = 'en') =>
   async (_: NextApiRequest, res: NextApiResponse<GetContributeServiceResponse>) => {
-    const url = json.fetch;
-
-    // In case executeClientScripts is true, ota snapshot fetcher will wait
-    // for selector to be found on the page, so resulting snapshot will be
-    // different each time a new selector is added
-    // same if language changes
-    const folderName = cleanStringForFileSystem(
-      `${url}_${acceptLanguage}${
-        json.executeClientScripts
-          ? `_${json.executeClientScripts}_${
-              json.select ? (Array.isArray(json.select) ? json.select.join(',') : json.select) : ''
-            }`
-          : ''
-      }`
-    );
-
-    const folderPath = path.join(serverRuntimeConfig.scrapedFilesFolder, folderName);
-
-    const newUrlPath = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}${
-      serverRuntimeConfig.scrapedIframeUrl
-    }/${folderName}`;
-
     try {
       const downloadResult = await downloadUrl(json, {
-        folderPath,
-        newUrlPath,
+        folderDirPath: serverRuntimeConfig.scrapedFilesFolder,
+        newUrlDirPath: `${process.env.NEXT_PUBLIC_BASE_PATH || ''}${
+          serverRuntimeConfig.scrapedIframeUrl
+        }`,
         acceptLanguage,
       });
 


### PR DESCRIPTION
Example with [Kindle Direct](https://contribute.opentermsarchive.org/en/service?destination=OpenTermsArchive%2Fp2b-compliance-declarations&name=Kindle%20Direct%20PublishingKDP%20Terms%20and%20Conditions&url=https://kdp-eu.amazon.com/agreement?token=eyJjbGllbnRJZCI6ImtpbmRsZV9kaXJlY3RfcHVibGlzaGluZyIsImRvY3VtZW50SWQiOiJrZHAiLCJjYW5jZWxVcmwiOiJodHRwczovL2tkcC5hbWF6b24uY29tIiwiY2xpZW50TG9jYWxlIjoiTkEiLCJkaXNwbGF5UGFyYW1zIjpudWxsLCJyYXdQYXJhbXMiOm51bGx9%7CeyJtYXRlcmlhbFNlcmlhbCI6MSwiaG1hYyI6Ik9pRzdzcG1UNm5LY25veWhlVG50cDRSQnBKVHAzQ1dwc2g0VXlDMDJKOW89IiwianNvbkhtYWMiOnRydWUsInR5cGUiOiJSRUFEX09OTFkiLCJhY2NlcHQiOmZhbHNlfQ&printView=true&language=en_US)

Fixes #100 

The directory name is used to keep downloaded URL in cache.





























