### PR TITLE
Fallback on original snapshot when body is empty

### DIFF
--- a/src/modules/Scraper/utils/downloader.ts
+++ b/src/modules/Scraper/utils/downloader.ts
@@ -265,7 +265,21 @@ export const downloadUrl = async (
     await waitForHashIfExists(page, parsedUrl.hash);
     await removeCookieBanners(page, hostname);
 
-    const html = await page.content();
+    let html = await page.content();
+
+    const body = await page.evaluate(() => document.querySelector('body')?.innerText);
+
+    // snapshot is sometimes correct but passing it inside puppeteer will
+    //  result in a problematic or empty body
+    if (
+      !body ||
+      // https://www.videdressing.com/static/ranking.html
+      body === '[object Object]' ||
+      // https://www.facebook.com/legal/commerce_ranking
+      body === 'Sorry! Something went wrong :('
+    ) {
+      html = snapshot.content.toString();
+    }
 
     fse.writeFileSync(indexFilePath, cleanHtml(html, assets));
   } catch (e: any) {


### PR DESCRIPTION
It happens that the only fact to pass the snapshot inside puppeeteer is causing problems.

In such a case, fallback to original snapshot while still replacing assets with their downloaded version on our server.