### PR TITLE
Refresh document types every 5 minutes

### DIFF
--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -597,6 +597,7 @@ export const getStaticProps = withI18n()(async (props: any) =>
   JSON.parse(
     JSON.stringify({
       props: { ...props, documentTypes: await getDocumentTypes() },
+      revalidate: 60 * 5,
     })
   )
 );


### PR DESCRIPTION
Next is creating static pages.
When no revalidation is put in place, everything that happens in the `getStaticProps` happens only at build time.

Let's refresh the list of document types every 5 minutes, staying way below the GitHub raw files rate limit of [5000 requests per hour](https://docs.github.com/en/developers/apps/building-github-apps/rate-limits-for-github-apps)