### PR TITLE
Handle commit url

### DIFF
--- a/src/modules/Common/services/useDocumentDeclaration.tsx
+++ b/src/modules/Common/services/useDocumentDeclaration.tsx
@@ -105,14 +105,8 @@ const useLatestDeclarationFileIfNeeded = () => {
     if (!data || !data.declaration) {
       return;
     }
-    const declaration: OTAJson = {
-      ...data.declaration,
-      documents: {
-        [documentType]: data.declaration.documents[documentType],
-      },
-    };
 
-    setLatestDeclaration(declaration);
+    setLatestDeclaration(data.declaration);
   }, [data]);
 
   return {

--- a/src/modules/Common/services/useDocumentDeclaration.tsx
+++ b/src/modules/Common/services/useDocumentDeclaration.tsx
@@ -2,7 +2,6 @@ import type { OTAJson, OTAPageDeclaration } from 'modules/Common/services/open-t
 import useUrl from 'hooks/useUrl';
 import React from 'react';
 import useSwr from 'swr';
-import { useToggle } from 'react-use';
 import { GetServiceFilesResponse } from 'modules/Common/interfaces';
 
 type PageArrayField = 'select' | 'remove';
@@ -125,7 +124,6 @@ const useDeclarationFromQueryParams = () => {
 
 const useDocumentDeclaration = () => {
   const { queryParams, pushQueryParam, pushQueryParams } = useUrl();
-  const [loadedFromSource, toggleLoadedFromSource] = useToggle(false);
 
   const { loading, latestDeclaration, declaration } = useDeclarationFromQueryParams();
 
@@ -133,15 +131,15 @@ const useDocumentDeclaration = () => {
   const [documentType, page] = document || [];
 
   const updateString = (field: PageStringField) => (value: string) => {
-    declaration.documents[documentType][field] = value.trim();
+    (declaration as OTAJson).documents[documentType][field] = value.trim();
     pushQueryParam('json')(JSON.stringify(declaration));
   };
 
   const updateBoolean = (field: PageBooleanField) => (value?: boolean) => {
     if (value) {
-      declaration.documents[documentType][field] = value;
+      (declaration as OTAJson).documents[documentType][field] = value;
     } else {
-      delete declaration.documents[documentType][field];
+      delete (declaration as OTAJson).documents[documentType][field];
     }
     pushQueryParam('json')(JSON.stringify(declaration));
   };
@@ -175,7 +173,7 @@ const useDocumentDeclaration = () => {
       }
 
       pageField = (pageField || []).filter(Boolean);
-      declaration.documents[documentType][field] = pageField;
+      (declaration as OTAJson).documents[documentType][field] = pageField;
 
       pushQueryParam('json')(JSON.stringify(declaration));
     };
@@ -186,9 +184,9 @@ const useDocumentDeclaration = () => {
         return;
       }
       if (field === 'documentType') {
-        declaration.documents = { [value]: page };
+        (declaration as OTAJson).documents = { [value]: page };
       } else {
-        declaration[field] = value;
+        (declaration as OTAJson)[field] = value;
       }
       pushQueryParam('json')(JSON.stringify(declaration));
     };
@@ -207,10 +205,10 @@ const useDocumentDeclaration = () => {
 
       // Reset page declaration when url is a PDF
       if (field === 'fetch' && typeof value === 'string' && value?.endsWith('.pdf')) {
-        delete declaration.documents[documentType].select;
-        delete declaration.documents[documentType].remove;
-        delete declaration.documents[documentType].filter;
-        delete declaration.documents[documentType].executeClientScripts;
+        delete (declaration as OTAJson).documents[documentType].select;
+        delete (declaration as OTAJson).documents[documentType].remove;
+        delete (declaration as OTAJson).documents[documentType].filter;
+        delete (declaration as OTAJson).documents[documentType].executeClientScripts;
         pushQueryParam('json')(JSON.stringify(declaration));
       }
     };
@@ -232,7 +230,6 @@ const useDocumentDeclaration = () => {
 
   React.useEffect(() => {
     if (latestDeclaration) {
-      toggleLoadedFromSource(true);
       pushQueryParams({
         ...queryParams,
         json: JSON.stringify(latestDeclaration),
@@ -248,7 +245,6 @@ const useDocumentDeclaration = () => {
 
   return {
     loading,
-    loadedFromSource,
     declaration,
     page,
     documentType,

--- a/src/modules/Common/services/useDocumentDeclaration.tsx
+++ b/src/modules/Common/services/useDocumentDeclaration.tsx
@@ -81,7 +81,7 @@ const createDeclarationFromQueryParams = (queryParams: any) => {
  * `url=undefined` query param
  * In this case this function will fetch the full data from GitHub
  */
-const useLatestDeclarationFileIfNeeded = () => {
+const useDeclarationFromQueryParams = () => {
   const { queryParams } = useUrl();
   const { destination, url, name, documentType, json, commit } = queryParams;
   const [latestDeclaration, setLatestDeclaration] = React.useState<OTAJson>();
@@ -94,7 +94,7 @@ const useLatestDeclarationFileIfNeeded = () => {
           destination,
           name,
           documentType,
-          commitURL: commit,
+          ...(commit ? { commitURL: commit } : {}),
         }
       : {}
   );
@@ -111,9 +111,15 @@ const useLatestDeclarationFileIfNeeded = () => {
     setLatestDeclaration(data.declaration);
   }, [data]);
 
+  const loading = shouldFetchOriginalDeclaration && !data && !json && !latestDeclaration;
+  const declaration = !shouldFetchOriginalDeclaration
+    ? createDeclarationFromQueryParams(queryParams)
+    : latestDeclaration;
+
   return {
-    loading: !data && shouldFetchOriginalDeclaration && !json,
+    loading,
     latestDeclaration,
+    declaration,
   };
 };
 
@@ -121,11 +127,9 @@ const useDocumentDeclaration = () => {
   const { queryParams, pushQueryParam, pushQueryParams } = useUrl();
   const [loadedFromSource, toggleLoadedFromSource] = useToggle(false);
 
-  const { loading, latestDeclaration } = useLatestDeclarationFileIfNeeded();
+  const { loading, latestDeclaration, declaration } = useDeclarationFromQueryParams();
 
-  const declaration = createDeclarationFromQueryParams(queryParams);
-
-  const [document] = Object.entries(declaration.documents || {}) || [[]];
+  const [document] = Object.entries(declaration?.documents || {}) || [[]];
   const [documentType, page] = document || [];
 
   const updateString = (field: PageStringField) => (value: string) => {

--- a/src/modules/Common/services/useDocumentDeclaration.tsx
+++ b/src/modules/Common/services/useDocumentDeclaration.tsx
@@ -83,16 +83,18 @@ const createDeclarationFromQueryParams = (queryParams: any) => {
  */
 const useLatestDeclarationFileIfNeeded = () => {
   const { queryParams } = useUrl();
-  const { destination, url, name, documentType, json } = queryParams;
+  const { destination, url, name, documentType, json, commit } = queryParams;
   const [latestDeclaration, setLatestDeclaration] = React.useState<OTAJson>();
 
-  const shouldFetchOriginalDeclaration = url === 'undefined';
+  const shouldFetchOriginalDeclaration = url === 'undefined' || commit;
+
   const searchParams = new URLSearchParams(
     shouldFetchOriginalDeclaration
       ? {
           destination,
           name,
           documentType,
+          commitURL: commit,
         }
       : {}
   );
@@ -219,6 +221,7 @@ const useDocumentDeclaration = () => {
         url: undefined,
         name: undefined,
         documentType: undefined,
+        commit: undefined,
       });
     }
   }, [queryParams.json, latestDeclaration, loading]);
@@ -234,6 +237,7 @@ const useDocumentDeclaration = () => {
         url: undefined,
         name: undefined,
         documentType: undefined,
+        commit: undefined,
       });
     }
   }, [latestDeclaration]);

--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -246,7 +246,6 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
         message: 'Update declaration from contribution tool',
         body: updateBody,
       });
-      throw e;
     }
   }
 

--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -40,15 +40,24 @@ export default class ServiceManager {
       .replace(/(&|\\|\/|:)/gi, '-'); // remove characters that might be problematic on the file system
   };
 
-  constructor({ destination, name, type }: { destination: string; name: string; type: string }) {
+  static getOrganizationAndRepository = (destination: string) => {
     if (!destination) {
       throw new Error('Destination is mandatory');
     }
     const [githubOrganization, githubRepository] = (destination || '')?.split('/');
 
     if (!authorizedOrganizations.includes(githubOrganization)) {
-      throw new Error('Destination should be OpenTermsArchive/something or ambanum/something');
+      throw new Error(
+        `Destination should be OpenTermsArchive/something or ambanum/something. Was ${destination}`
+      );
     }
+
+    return { githubOrganization, githubRepository };
+  };
+
+  constructor({ destination, name, type }: { destination: string; name: string; type: string }) {
+    const { githubOrganization, githubRepository } =
+      ServiceManager.getOrganizationAndRepository(destination);
 
     this.githubOrganization = githubOrganization;
     this.githubRepository = githubRepository;

--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -256,8 +256,15 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
       branch: 'main',
     });
 
+    const fullDeclaration = JSON.parse(existingContentString) as OTAJson;
+
     return {
-      declaration: JSON.parse(existingContentString) as OTAJson,
+      declaration: {
+        ...fullDeclaration,
+        documents: {
+          [this.type]: fullDeclaration.documents[this.type],
+        },
+      },
     };
   };
 }

--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -438,3 +438,24 @@ export const getIssueComments = async ({ issue_number, ...searchParams }: any) =
     throw e;
   }
 };
+
+export const getDataFromCommit = async ({
+  commitId,
+  ...params
+}: {
+  commitId: string;
+  owner: string;
+  repo: string;
+}) => {
+  try {
+    const { data } = await octokit.rest.repos.getCommit({
+      ...params,
+      ref: commitId,
+    });
+    return data;
+  } catch (e: any) {
+    console.error(`Could not get data from commit ${commitId}`);
+    console.error(e.toString());
+    throw e;
+  }
+};

--- a/src/pages/api/services/files.ts
+++ b/src/pages/api/services/files.ts
@@ -5,14 +5,25 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import HttpStatusCode from 'http-status-codes';
 import ServiceManager from 'modules/Contribute/managers/ServiceManager';
 const get =
-  ({ name, documentType, destination }: any) =>
+  ({ name, documentType, destination, commitURL }: any) =>
   async (_: NextApiRequest, res: NextApiResponse<GetServiceFilesResponse>) => {
     try {
-      const serviceManager = new ServiceManager({
-        destination,
-        name,
-        type: documentType,
-      });
+      let serviceManager;
+
+      if (commitURL) {
+        const commit = await ServiceManager.getDataFromCommit(commitURL);
+        serviceManager = new ServiceManager({
+          destination,
+          name: commit.service,
+          type: commit.documentType,
+        });
+      } else {
+        serviceManager = new ServiceManager({
+          destination,
+          name,
+          type: documentType,
+        });
+      }
 
       const files = await serviceManager.getDeclarationFiles();
 
@@ -42,6 +53,7 @@ const files = async (req: NextApiRequest, res: NextApiResponse) => {
       destination: query?.destination,
       name: query?.name,
       documentType: query?.documentType,
+      commitURL: query?.commitURL,
     })(req, res);
   }
 

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -58,7 +58,6 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
   // Declaration
   const {
     loading: loadingDocumentDeclaration,
-    loadedFromSource,
     page,
     declaration,
     documentType,
@@ -168,7 +167,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
       } = await api.post<PostContributeServiceResponse>('/api/services', {
         destination,
         json: declaration,
-        name: declaration.name,
+        name: declaration?.name,
         documentType: documentType,
         url: `${window.location.href}&expertMode=true`,
       });
@@ -177,7 +176,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
         const subject = 'Here is a new service to track in Open Terms Archive';
         const body = `Hi,
 
-  I need you to track "${documentType}" of "${declaration.name}" for me.
+  I need you to track "${documentType}" of "${declaration?.name}" for me.
 
   Here is the url ${window.location.href}&expertMode=true
 
@@ -214,7 +213,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
     const subject = 'I tried to add this service but it did not work';
     const body = `Hi,
 
-I need you to track "${documentType}" of "${declaration.name}" for me but I had a failure with.
+I need you to track "${documentType}" of "${declaration?.name}" for me but I had a failure with.
 
 -----
 ${error}

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -241,6 +241,9 @@ Thank you very much`;
   if (loadingDocumentDeclaration) {
     return 'Loading declaration from source...';
   }
+  if (!declaration) {
+    return 'Loading declaration...';
+  }
 
   return (
     <div className={s.wrapper}>
@@ -260,11 +263,6 @@ Thank you very much`;
               {t('service:back')}
             </LinkIcon>
           </nav>
-          {loadedFromSource && (
-            <div key="loaded-from-source">
-              Declaration loaded from source, please refresh the page.
-            </div>
-          )}
           <div className={s.formWrapper}>
             <form>
               <div className={classNames('formfield')}>


### PR DESCRIPTION
In order to easily fix a document, implement a way to pass the commit URL to the contribution tool to gather directly the corresponding file.

This kind of url can then be used

`/service?commit=https://github.com/OpenTermsArchive/contrib-versions/commit/03f6e40378612b8b1a3c16ec041bd18d6db94744`