### PR TITLE
Create PR when updating document

### DIFF
--- a/locales/en/service.json
+++ b/locales/en/service.json
@@ -33,5 +33,5 @@
   "loading.title": "We're preparing the website",
   "send_email": "Send us an email",
   "verify": "Verify version",
-  "submit": "Add document"
+  "submit": "Send document"
 }

--- a/locales/fr/service.json
+++ b/locales/fr/service.json
@@ -33,5 +33,5 @@
   "loading.title": "Nous préparons le site Web",
   "send_email": "Envoyez-nous un email",
   "verify": "Vérifier la version",
-  "submit": "Ajouter le document"
+  "submit": "Envoyer le document"
 }

--- a/src/modules/Common/hooks/useConfigDeclaration.tsx
+++ b/src/modules/Common/hooks/useConfigDeclaration.tsx
@@ -2,12 +2,12 @@ import useUrl from 'hooks/useUrl';
 
 const useConfigDeclaration = () => {
   const {
-    queryParams: { destination, localPath, acceptLanguage, hiddenCss, expertMode },
+    queryParams: { destination, localPath, acceptLanguage, hiddenCss, expertMode, url },
     pushQueryParam,
     removeQueryParam,
   } = useUrl();
 
-  if (!destination && typeof window !== 'undefined') {
+  if (!destination && url && typeof window !== 'undefined') {
     // This is here as previously created issues still point at a url that has no `destination` param
     pushQueryParam('destination')('OpenTermsArchive/contrib-declarations');
   }

--- a/src/modules/Common/interfaces/index.ts
+++ b/src/modules/Common/interfaces/index.ts
@@ -15,6 +15,7 @@ export interface GetServiceVerifyResponse extends CommonResponse {
 export interface GetServiceFilesResponse extends CommonResponse {
   error?: string;
   declaration?: OTAJson;
+  destination?: string;
 }
 
 export interface GetContributeServiceResponse extends CommonResponse {

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -171,9 +171,11 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
         return await updateDocumentsInBranch({
           ...this.commonParams,
           branch: branchName,
+          targetBranch: 'main',
           content: json,
           filePath: this.declarationFilePath,
           message: 'Update declaration from contribution tool',
+          title: prTitle,
           body: updateBody,
         });
       }
@@ -248,12 +250,14 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
       return await updateDocumentsInBranch({
         ...this.commonParams,
         documentType: this.type,
+        targetBranch: 'main',
         branch: branchName,
         content: json,
         filePath: this.declarationFilePath,
         historyFilePath: this.historyFilePath,
         historyMessage: 'Update history from contribution tool',
         message: 'Update declaration from contribution tool',
+        title: prTitle,
         body: updateBody,
       });
     }

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -260,12 +260,14 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
     const fullDeclaration = JSON.parse(existingContentString) as OTAJson;
 
     return {
-      declaration: {
-        ...fullDeclaration,
-        documents: {
-          [this.type]: fullDeclaration.documents[this.type],
-        },
-      },
+      declaration: fullDeclaration.documents[this.type]
+        ? {
+            ...fullDeclaration,
+            documents: {
+              [this.type]: fullDeclaration.documents[this.type],
+            },
+          }
+        : null,
     };
   };
 

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -273,6 +273,10 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
       branch: 'main',
     });
 
+    if (!existingContentString) {
+      return { declaration: null };
+    }
+
     const fullDeclaration = JSON.parse(existingContentString) as OTAJson;
 
     return {

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -78,7 +78,6 @@ export default class ServiceManager {
   public async addOrUpdateService({ json, url }: { json: any; url: string }) {
     const { origin } = new URL(url);
     const localUrl = url.replace(origin, 'http://localhost:3000');
-    let lastFailingDate;
 
     const { declaration } = await this.getDeclarationFiles();
 
@@ -87,7 +86,7 @@ export default class ServiceManager {
     }
 
     try {
-      lastFailingDate = await getLatestFailDate({
+      const { lastFailingDate, issueNumber } = await getLatestFailDate({
         ...this.commonParams,
         serviceName: this.name,
         documentType: this.type,
@@ -97,6 +96,7 @@ export default class ServiceManager {
         url,
         localUrl,
         lastFailingDate,
+        issueNumber,
       });
     } catch (e: any) {
       return this.updateService({
@@ -188,10 +188,12 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
     url,
     localUrl,
     lastFailingDate,
+    issueNumber,
   }: {
     json: any;
     url: string;
-    lastFailingDate: string;
+    lastFailingDate?: string;
+    issueNumber?: string;
     localUrl: string;
   }) {
     const prTitle = `Update ${this.name} ${this.type}`;
@@ -209,6 +211,7 @@ ${checkBoxes.join('\n')}
 
 Thanks to your work and attention, Open Terms Archive will ensure that high quality data is available for all reusers, enabling them to do their part in shifting the balance of power towards end users and regulators instead of spending time collecting and cleaning documents 💪
 
+${issueNumber ? `Fixes #${issueNumber}` : ''}
 - - -
 
 _This update suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents.

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -193,7 +193,7 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
     json: any;
     url: string;
     lastFailingDate?: string;
-    issueNumber?: string;
+    issueNumber?: number;
     localUrl: string;
   }) {
     const prTitle = `Update ${this.name} ${this.type}`;
@@ -294,9 +294,10 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
   static getDataFromCommit = async (commitURL: string) => {
     const { pathname } = new URL(commitURL);
 
-    const [destination, commitId] = pathname.replace(/^\//g, '').split('/commit/');
+    let [repo, commitId] = pathname.replace(/^\//g, '').split('/commit/');
     const { githubOrganization, githubRepository } =
-      ServiceManager.getOrganizationAndRepository(destination);
+      ServiceManager.getOrganizationAndRepository(repo);
+
     const { commit, files } = await getDataFromCommit({
       commitId,
       owner: githubOrganization,
@@ -310,6 +311,12 @@ You can load it [on your local instance](${localUrl}) if you have one set up._
     const filename = files[0].filename.replace(/\.md$/, '');
     const [service, documentType] = filename.split('/');
 
-    return { service, documentType, message: commit?.message, date: commit?.committer?.date };
+    return {
+      service,
+      documentType,
+      message: commit?.message,
+      date: commit?.committer?.date,
+      destination: repo.replace('-versions', '-declarations'),
+    };
   };
 }

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -79,13 +79,19 @@ export default class ServiceManager {
     const { origin } = new URL(url);
     const localUrl = url.replace(origin, 'http://localhost:3000');
     let lastFailingDate;
+
+    const { declaration } = await this.getDeclarationFiles();
+
+    if (!declaration) {
+      return this.addService({ json, url, localUrl });
+    }
+
     try {
       lastFailingDate = await getLatestFailDate({
         ...this.commonParams,
         serviceName: this.name,
         documentType: this.type,
       });
-
       return this.updateService({
         json,
         url,
@@ -93,8 +99,11 @@ export default class ServiceManager {
         lastFailingDate,
       });
     } catch (e: any) {
-      console.log('Try adding service');
-      return this.addService({ json, url, localUrl });
+      return this.updateService({
+        json,
+        url,
+        localUrl,
+      });
     }
   }
 

--- a/src/modules/Common/services/useDocumentDeclaration.tsx
+++ b/src/modules/Common/services/useDocumentDeclaration.tsx
@@ -81,7 +81,7 @@ const createDeclarationFromQueryParams = (queryParams: any) => {
  * In this case this function will fetch the full data from GitHub
  */
 const useDeclarationFromQueryParams = () => {
-  const { queryParams } = useUrl();
+  const { queryParams, pushQueryParam } = useUrl();
   const { destination, url, name, documentType, json, commit } = queryParams;
   const [latestDeclaration, setLatestDeclaration] = React.useState<OTAJson>();
 
@@ -108,6 +108,7 @@ const useDeclarationFromQueryParams = () => {
     }
 
     setLatestDeclaration(data.declaration);
+    if (data.destination) pushQueryParam('destination')(data.destination);
   }, [data]);
 
   const loading = shouldFetchOriginalDeclaration && !data && !json && !latestDeclaration;

--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -186,6 +186,8 @@ export const updateDocumentsInBranch = async ({
   filePath,
   historyFilePath,
   branch,
+  title,
+  targetBranch,
   documentType,
   lastFailingDate,
   message,
@@ -196,6 +198,8 @@ export const updateDocumentsInBranch = async ({
 }: {
   filePath: string;
   branch: string;
+  targetBranch: string;
+  title: string;
   content: any;
   owner: string;
   message: string;
@@ -253,13 +257,23 @@ export const updateDocumentsInBranch = async ({
 
   const existingPr = existingPrs[0];
 
-  await octokit.rest.issues.createComment({
-    ...params,
-    body,
-    issue_number: existingPr.number,
-  });
-
-  return existingPrs[0];
+  if (existingPr) {
+    await octokit.rest.issues.createComment({
+      ...params,
+      body,
+      issue_number: existingPr.number,
+    });
+    return existingPrs[0];
+  } else {
+    const { data } = await octokit.rest.pulls.create({
+      ...params,
+      base: targetBranch,
+      head: branch,
+      title,
+      body,
+    });
+    return data;
+  }
 };
 
 export const createDocumentUpdatePullRequest = async ({

--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -424,7 +424,10 @@ export const getLatestFailDate = async ({ serviceName, documentType, ...commonPa
     );
 
     const mostRecentFailingComment = failingComments[failingComments.length - 1];
-    return mostRecentFailingComment.createdAt;
+    return {
+      issueNumber: issue.number,
+      lastFailingDate: mostRecentFailingComment.createdAt,
+    };
   } catch (e: any) {
     console.error('Could not search issue');
     console.error(e.toString());

--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -242,7 +242,7 @@ export const updateDocumentsInBranch = async ({
           ...(existingContent[documentType] || []),
           {
             ...contentToInsert,
-            validUntil: lastFailingDate || new Date().toISOString(),
+            validUntil: lastFailingDate || 'to-be-determined',
           },
         ],
       }),
@@ -300,7 +300,7 @@ export const createDocumentUpdatePullRequest = async ({
   owner: string;
   message: string;
   historyMessage: string;
-  lastFailingDate: string;
+  lastFailingDate?: string;
   body: string;
   repo: string;
 }) => {
@@ -341,7 +341,7 @@ export const createDocumentUpdatePullRequest = async ({
         ...(existingContent[documentType] || []),
         {
           ...contentToInsert,
-          validUntil: lastFailingDate || new Date().toISOString(),
+          validUntil: lastFailingDate || 'to-be-determined',
         },
       ],
     }),

--- a/src/pages/api/services/files.ts
+++ b/src/pages/api/services/files.ts
@@ -5,13 +5,14 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import HttpStatusCode from 'http-status-codes';
 import ServiceManager from 'modules/Common/managers/ServiceManager';
 const get =
-  ({ name, documentType, destination, commitURL }: any) =>
+  ({ name, documentType, destination: queryDestination, commitURL }: any) =>
   async (_: NextApiRequest, res: NextApiResponse<GetServiceFilesResponse>) => {
     try {
       let serviceManager;
-
+      let destination = queryDestination;
       if (commitURL) {
         const commit = await ServiceManager.getDataFromCommit(commitURL);
+        destination = commit.destination;
         serviceManager = new ServiceManager({
           destination,
           name: commit.service,
@@ -30,7 +31,8 @@ const get =
       res.json({
         status: 'ok',
         message: 'OK',
-        ...files,
+        destination,
+        ...(files as any),
       });
       return res;
     } catch (e: any) {

--- a/src/pages/api/services/index.ts
+++ b/src/pages/api/services/index.ts
@@ -86,14 +86,14 @@ const saveHistoryFile = async ({
     repo: githubRepository,
     accept: 'application/vnd.github.v3+json',
   };
-  let lastFailingDate: string;
+  let lastFailingDate: any;
 
   try {
-    lastFailingDate = await getLatestFailDate({
+    ({ lastFailingDate } = await getLatestFailDate({
       ...commonParams,
       serviceName,
       documentType,
-    });
+    }));
   } catch (e) {}
 
   const newHistoryJson = {

--- a/src/pages/api/services/index.ts
+++ b/src/pages/api/services/index.ts
@@ -94,16 +94,14 @@ const saveHistoryFile = async ({
       serviceName,
       documentType,
     });
-  } catch (e) {
-    lastFailingDate = new Date().toISOString();
-  }
+  } catch (e) {}
 
   const newHistoryJson = {
     ...historyJson,
     [documentType]: [
       {
         ...existingJson.documents[documentType],
-        validUntil: dayjs(lastFailingDate || new Date()).format(),
+        validUntil: lastFailingDate ? dayjs(lastFailingDate).format() : 'to-be-determined',
       },
       ...(historyJson[documentType] || []),
     ],

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -517,8 +517,8 @@ Thank you very much`;
               <Button disabled={submitDisabled} type="secondary" onClick={onVerify}>
                 {t('service:verify')}
               </Button>
-              <Button disabled={submitDisabled} onClick={onValidate}>
-                {loading ? '...' : t('service:submit')}
+              <Button disabled={submitDisabled || loading} onClick={onValidate}>
+                {t('service:submit')}
               </Button>
             </nav>
           </div>

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -94,7 +94,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
   }
 
   const { data, error: apiError } = useSWR<GetContributeServiceResponse>(
-    `/api/services?${apiUrlParams}`,
+    declaration ? `/api/services?${apiUrlParams}` : null,
     {
       revalidateOnMount: true,
       revalidateIfStale: false,


### PR DESCRIPTION
As of now, when an issue is created by OTA core, it uses a link to the contribution tool in the description that automatically handles the creation of a PR on submit.

When such an issue does not exist though, it only modifies the declaration.

This PR handles this specific case by
- updating the declaration file
- creating the history file