### PR TITLE
Make sure destination is present in query params

### DIFF
--- a/src/modules/Common/services/useDocumentDeclaration.tsx
+++ b/src/modules/Common/services/useDocumentDeclaration.tsx
@@ -251,7 +251,7 @@ const useDocumentDeclaration = () => {
         commit: undefined,
       });
     }
-  }, [latestDeclaration]);
+  }, [queryParams, latestDeclaration]);
 
   return {
     loading,


### PR DESCRIPTION
As passing of query params in the url can't be awaited and this is done in at least two spots in the code, it sometimes happen that one change of the destination is getting lost.

This PR makes sute it does not