### PR TITLE
Always format declaration correctly

### DIFF
--- a/src/modules/Common/services/useDocumentDeclaration.tsx
+++ b/src/modules/Common/services/useDocumentDeclaration.tsx
@@ -121,9 +121,12 @@ const useDeclarationFromQueryParams = () => {
   }, [data?.destination, queryParams.destination]);
 
   const loading = shouldFetchOriginalDeclaration && !data && !json && !latestDeclaration;
+
   const declaration = !shouldFetchOriginalDeclaration
     ? createDeclarationFromQueryParams(queryParams)
-    : latestDeclaration;
+    : latestDeclaration
+    ? formatJSONfields(latestDeclaration)
+    : undefined;
 
   return {
     loading,


### PR DESCRIPTION
In order to handle cases when range selector is not in an array such as for https://github.com/OpenTermsArchive/dating-versions/commit/99c49a8f08b5ce4159925e26bbeabc499fb96778