### PR TITLE
Authorize chrome inspector

### DIFF
--- a/public/iframe-selector/injected-script.js
+++ b/public/iframe-selector/injected-script.js
@@ -24,7 +24,6 @@ const pickEnabledCss = `
 const pickDisabledCss = `
 * {
   cursor: not-allowed;
-  pointer-events: none;
 }
 `;
 


### PR DESCRIPTION
Having this CSS rule prevents selection of any node when using the built in browser inspector