### PR TITLE
Make cookie bypassing optional

### DIFF
--- a/locales/en/service.json
+++ b/locales/en/service.json
@@ -29,6 +29,8 @@
   "form.url": "URL",
   "form.acceptLanguage": "Force language (fr, es, ...)",
   "form.acceptLanguage.more": "If the language of the document is not the one you were expecting.",
+  "form.bypassCookies": "Bypass cookies",
+  "form.bypassCookies.more": "Often, cookie banners or modals gets in the way. Check this to try to bypass them.",
   "loading.subtitle": "It usually takes between 5s and 30s",
   "loading.title": "We're preparing the website",
   "send_email": "Send us an email",

--- a/locales/fr/service.json
+++ b/locales/fr/service.json
@@ -29,6 +29,8 @@
   "form.url": "URL",
   "form.acceptLanguage": "Forcer la langue (fr, es, ...)",
   "form.acceptLanguage.more": "Si la langue du document n'est pas celle que vous attendiez.",
+  "form.bypassCookies": "Eviter les cookies",
+  "form.bypassCookies.more": "Régulièrement, des bannières de cookies ou des popup s'interposent. Cochez pour essayer de les contourner.",
   "loading.subtitle": "Cela prend généralement entre 5s et 30s",
   "loading.title": "Nous préparons le site Web",
   "send_email": "Envoyez-nous un email",

--- a/src/modules/Common/hooks/useConfigDeclaration.tsx
+++ b/src/modules/Common/hooks/useConfigDeclaration.tsx
@@ -2,7 +2,15 @@ import useUrl from 'hooks/useUrl';
 
 const useConfigDeclaration = () => {
   const {
-    queryParams: { destination, localPath, acceptLanguage, hiddenCss, expertMode, url },
+    queryParams: {
+      destination,
+      localPath,
+      acceptLanguage,
+      hiddenCss,
+      expertMode,
+      url,
+      bypassCookies,
+    },
     pushQueryParam,
     removeQueryParam,
   } = useUrl();
@@ -29,7 +37,7 @@ const useConfigDeclaration = () => {
     };
 
   const onConfigInputChange =
-    (field: 'acceptLanguage' | 'expertMode') => (value: boolean | string) => {
+    (field: 'acceptLanguage' | 'expertMode' | 'bypassCookies') => (value: boolean | string) => {
       if (value) {
         pushQueryParam(field)(typeof value === 'boolean' ? 'true' : value);
       } else {
@@ -45,6 +53,7 @@ const useConfigDeclaration = () => {
     hiddenCssSelectors,
     onConfigInputChange,
     expertMode,
+    bypassCookies,
   };
 };
 

--- a/src/modules/I18n/i18n.js
+++ b/src/modules/I18n/i18n.js
@@ -2,7 +2,7 @@ module.exports = {
   locales: ['en', 'fr'],
   defaultLocale: 'en',
   keySeparator: false, // to be able to use `.` in the key names
-  // logBuild: false,
+  logBuild: false,
   pages: {
     '*': ['common', 'header', 'footer'],
     '/': ['homepage'],

--- a/src/modules/Scraper/utils/downloader.ts
+++ b/src/modules/Scraper/utils/downloader.ts
@@ -117,7 +117,13 @@ export const downloadUrl = async (
     folderDirPath,
     newUrlDirPath,
     acceptLanguage = 'en',
-  }: { folderDirPath: string; newUrlDirPath: string; acceptLanguage?: string }
+    bypassCookies = false,
+  }: {
+    folderDirPath: string;
+    newUrlDirPath: string;
+    acceptLanguage?: string;
+    bypassCookies?: boolean;
+  }
 ): Promise<DownloadResult> => {
   const folderName = generateFolderName(json, acceptLanguage);
   const folderPath = path.join(folderDirPath, folderName);
@@ -127,16 +133,19 @@ export const downloadUrl = async (
   const snapshotFilePath = `${folderPath}/snapshot.html`;
   const indexFilePath = `${folderPath}/index.html`;
   const newUrl = `${newUrlPath}/index.html`;
+  const newSnapshotUrl = `${newUrlPath}/snapshot.html`;
 
   const snapshotPDFFilePath = `${folderPath}/snapshot.pdf`;
   const newPDFUrl = `${newUrlPath}/snapshot.pdf`;
+
+  const iframeUrl = bypassCookies ? newSnapshotUrl : newUrl;
 
   if (fse.existsSync(folderPath)) {
     const existingFiles = fse.readdirSync(folderPath);
     if (existingFiles.includes('snapshot.pdf')) {
       return { url: newPDFUrl, isPDF: true };
     }
-    return { url: newUrl };
+    return { url: iframeUrl };
   }
 
   fse.ensureDirSync(folderPath);
@@ -293,5 +302,6 @@ export const downloadUrl = async (
   await stopBrowser();
 
   console.timeEnd(timerLabel);
-  return { url: newUrl };
+
+  return { url: iframeUrl };
 };

--- a/src/modules/Scraper/utils/downloader.ts
+++ b/src/modules/Scraper/utils/downloader.ts
@@ -171,7 +171,6 @@ export const downloadUrl = async (
   }
 
   fse.ensureFileSync(indexFilePath);
-  fse.writeFileSync(snapshotFilePath, snapshot.content);
   const browser: Browser = await launchBrowser();
 
   const page = await browser.newPage();
@@ -281,6 +280,7 @@ export const downloadUrl = async (
       html = snapshot.content.toString();
     }
 
+    fse.writeFileSync(snapshotFilePath, cleanHtml(snapshot.content, assets));
     fse.writeFileSync(indexFilePath, cleanHtml(html, assets));
   } catch (e: any) {
     console.error(e.toString());

--- a/src/pages/api/services/index.ts
+++ b/src/pages/api/services/index.ts
@@ -16,7 +16,7 @@ import { getLatestFailDate } from 'modules/Github/api';
 const { serverRuntimeConfig } = getConfig();
 
 const get =
-  (json: any, acceptLanguage: string = 'en') =>
+  (json: any, { acceptLanguage = 'en' }: { acceptLanguage: string }) =>
   async (_: NextApiRequest, res: NextApiResponse<GetContributeServiceResponse>) => {
     try {
       if (json.combine) {
@@ -193,7 +193,9 @@ const services = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === 'GET' && query?.json) {
     try {
       const json = JSON.parse(query.json as string);
-      return get(json, query.acceptLanguage as string)(req, res);
+      return get(json, {
+        acceptLanguage: query.acceptLanguage as string,
+      })(req, res);
     } catch (e: any) {
       res.statusCode = HttpStatusCode.METHOD_FAILURE;
       res.json({ status: 'ko', message: 'Error occured', error: e.toString() });

--- a/src/pages/api/services/index.ts
+++ b/src/pages/api/services/index.ts
@@ -16,7 +16,10 @@ import { getLatestFailDate } from 'modules/Github/api';
 const { serverRuntimeConfig } = getConfig();
 
 const get =
-  (json: any, { acceptLanguage = 'en' }: { acceptLanguage: string }) =>
+  (
+    json: any,
+    { acceptLanguage = 'en', bypassCookies }: { acceptLanguage: string; bypassCookies: boolean }
+  ) =>
   async (_: NextApiRequest, res: NextApiResponse<GetContributeServiceResponse>) => {
     try {
       if (json.combine) {
@@ -35,6 +38,7 @@ const get =
           serverRuntimeConfig.scrapedIframeUrl
         }`,
         acceptLanguage,
+        bypassCookies,
       });
 
       const { url: newUrl, isPDF } = downloadResult;
@@ -195,6 +199,7 @@ const services = async (req: NextApiRequest, res: NextApiResponse) => {
       const json = JSON.parse(query.json as string);
       return get(json, {
         acceptLanguage: query.acceptLanguage as string,
+        bypassCookies: (query.bypassCookies as string) === 'true' ? true : false,
       })(req, res);
     } catch (e: any) {
       res.statusCode = HttpStatusCode.METHOD_FAILURE;

--- a/src/pages/service.module.css
+++ b/src/pages/service.module.css
@@ -98,7 +98,7 @@
 }
 
 .moreinfo {
-  margin-top: calc(-1 * var(--mXS));
+  margin-top: calc(-0.5 * var(--mXS));
   font-style: italic;
   margin-bottom: var(--mXS);
   display: block;

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -72,6 +72,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
     onConfigInputChange,
     onHiddenCssSelectorsUpdate,
     expertMode,
+    bypassCookies,
     acceptLanguage,
   } = useConfigDeclaration();
 
@@ -91,6 +92,9 @@ const ServicePage = ({ documentTypes }: { documentTypes: DocumentTypes }) => {
 
   if (acceptLanguage) {
     apiUrlParams = `${apiUrlParams}&acceptLanguage=${encodeURIComponent(acceptLanguage)}`;
+  }
+  if (bypassCookies) {
+    apiUrlParams = `${apiUrlParams}&bypassCookies=true`;
   }
 
   const { data, error: apiError } = useSWR<GetContributeServiceResponse>(
@@ -436,6 +440,18 @@ Thank you very much`;
                             event.target.checked
                           )
                         }
+                        disabled={isPDF}
+                      />
+                    </div>
+                  </div>
+                  <div className={classNames('formfield')}>
+                    <label>{t('service:form.bypassCookies')}</label>
+                    <small className={s.moreinfo}>{t('service:form.bypassCookies.more')}</small>
+                    <div className={classNames('select')}>
+                      <input
+                        type="checkbox"
+                        defaultChecked={!!bypassCookies}
+                        onChange={() => onConfigInputChange('bypassCookies')(!bypassCookies)}
                         disabled={isPDF}
                       />
                     </div>


### PR DESCRIPTION
As [seen here](https://github.com/OpenTermsArchive/pga-declarations/pull/78#issuecomment-1296714101), the contribution tool sometimes render empty pages that are difficult to interpret as a user.

This can be due to the fact that the cookie banner remover is modifying the snapshot.

In this PR, I make this bypass optional by checking a box in the expert mode. 