### PR TITLE
Add checks and alert messages to prevent internal URLs

### DIFF
--- a/src/pages/homepage.tsx
+++ b/src/pages/homepage.tsx
@@ -23,10 +23,15 @@ const HomePage = ({ mdxContent }: WithMdxResult) => {
   });
 
   const onSubmit: SearchProps['onSearchSubmit'] = async (url) => {
-    try {
-      router.push(`/service?${commonUrlParams}&url=${encodeURIComponent(url)}`);
-    } catch (e) {
-      console.error(e);
+    if ((url.toLowerCase().includes("localhost")) || (url.toLowerCase().includes("127.0.0.1"))) {
+        alert("Wrong URL! Please check the URL and enter it correctly.");
+        console.error("Wrong URL");
+    } else {
+        try {
+                router.push(`/service?${commonUrlParams}&url=${encodeURIComponent(url)}`);
+        } catch (e) {
+                console.error(e);
+        }
     }
   };
 

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -1,4 +1,4 @@
-import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
+﻿import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
 import {
   GetContributeServiceResponse,
   PostContributeServiceResponse,
@@ -105,6 +105,14 @@ const ServicePage = ({
     )
   )}`;
 
+  if ((apiUrlParams.toLowerCase().includes("localhost")) || (apiUrlParams.toLowerCase().includes("127.0.0.1"))) {
+        alert("Wrong URL! Please check the URL and enter it correctly.");
+        console.error("Wrong URL");
+	apiUrlParams = apiUrlParams.replace("localhost", "");
+	apiUrlParams = apiUrlParams.replace("127.0.0.1", "");
+  }
+
+
   if (acceptLanguage) {
     apiUrlParams = `${apiUrlParams}&acceptLanguage=${encodeURIComponent(acceptLanguage)}`;
   }
@@ -195,7 +203,7 @@ const ServicePage = ({
       });
 
       if (!url) {
-        const subject = 'Here is a new service to track in Open Terms Archive';
+        const subject = 'Here is a new service to track in Open Terms Archive';
         const body = `Hi,
 
   I need you to track "${documentType}" of "${declaration?.name}" for me.


### PR DESCRIPTION
As reported on my issue (https://github.com/OpenTermsArchive/contribution-tool/issues/158), we modified the code in order to prevent the possibility to use the server to interact with the internal URLs.
For the moment we introduced a check to inform the user and then we sanitize the wrong URLs removing all internal reference.