### PR TITLE
Ensure that the Nodesource key import does not get stuck

### DIFF
--- a/ops/roles/infra/node/tasks/main.yml
+++ b/ops/roles/infra/node/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: "755"
 
 - name: Download and import the Nodesource GPG key
-  ansible.builtin.shell: set -o pipefail && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  ansible.builtin.shell: set -o pipefail && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg
   args:
     executable: /bin/bash
 


### PR DESCRIPTION
This can happen if the key is already imported, the `gpg` command asks if it should overwrite it