### PR TITLE
Add GitLab compatibility for saving data to repository

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,11 @@ PORT=3000
 
 # Automatically create Github issue on contribution
 GITHUB_TOKEN= #create one with repo privileges here https://github.com/settings/tokens
+
+NEXT_PUBLIC_REPO_TYPE= #If it's set to GITLAB it uses Gitlab as repository. If it's blank it uses Github.
+
+NEXT_PUBLIC_CONTRIBUTION_TOOL_URL= #Contribution-Tool's production url
+NEXT_PUBLIC_CONTRIBUTION_TOOL_LABEL= #Contribution-Tool's production label 
+GITLAB_URL= #GITLAB API url
+GITLAB_PROJECT_ID= #GITLAB Project Identifier associated to declarations repository
+GITLAB_TOKEN= #create one with repo privileges on the declarations repository 

--- a/content/parts/en/contributor-form-gitlab.mdx
+++ b/content/parts/en/contributor-form-gitlab.mdx
@@ -1,0 +1,20 @@
+## Submit document
+
+Open Terms Archive is an open source initiative that relies on contributors just like you 🤗
+
+#### Sign your contribution
+
+By default, your contributions will be anonymous. Signing your contributions enables you to be credited publicly for them and to be notified when they are integrated or discussed.
+
+<ContributorFormFields />
+
+- While not readable anywhere on the web, this email address will be [publicly](https://stackoverflow.com/a/897604/594053) and irreversibly associated with your contribution.
+- We will use this address only if it is necessary to contact you for integrating, crediting or otherwise handling this specific contribution.
+- If you have an account on [GitLab](https://gitlab.com), using an address linked to it will enable mentioning your account.
+
+<small>
+  If you want to contribute anonymously, you can leave the default email. You can always join the
+  discussion later, but maintainers will not be able to proactively contact you if they have
+  questions.
+</small>
+

--- a/content/parts/fr/contributor-form-gitlab.mdx
+++ b/content/parts/fr/contributor-form-gitlab.mdx
@@ -1,0 +1,15 @@
+## Signer votre contribution
+
+Open Terms Archive est une initiative open source qui repose sur des contributrices et contributeurs comme vous 🤗
+
+Par défaut, vos contributions sont anonymes. Signer vos contributions vous permet d’en avoir publiquement la paternité et de recevoir une notification lorsque celles-ci seront intégrées ou discutées.
+
+<ContributorFormFields />
+
+- Bien qu’elle ne soit pas lisible directement sur le web, cette adresse électronique sera associée à votre contribution de manière [publique](https://stackoverflow.com/a/897604/594053) et irréversible.
+- Nous n’utiliserons cette adresse que s’il est nécessaire de vous contacter pour intégrer, créditer ou traiter cette contribution.
+- Si vous avez un compte [GitLab](https://gitlab.com), utiliser une adresse qui y est associée permettra de le mentionner.
+
+<small>
+  Si vous souhaitez contribuer de manière anonyme, vous pouvez laisser l’adresse électronique par défaut. Vous pourrez toujours rejoindre la discussion plus tard, mais les mainteneurs ne pourront pas vous contacter si cette contribution pose question.
+</small>

--- a/content/static/en/thanks-gitlab.mdx
+++ b/content/static/en/thanks-gitlab.mdx
@@ -1,7 +1,8 @@
 ## Thank you for your contribution to Open Terms Archive!
 
-Your suggestion has been turned to a <a href={url} target="_blank">pull request</a> on GitHub. You can follow the status of your suggestion there and communicate with us about it by creating an account on GitHub.
+Your suggestion has been turned to a <a href={url} target="_blank">pull request</a> on GitLab. You can follow the status of your suggestion there and communicate with us about it by creating an account on GitLab.
 
 In order to guarantee a high quality of data, we test each contribution individually to make sure it works as intended and is stable over time. We do our best to start tracking the document you suggested as fast as possible, but these checks may take a few days.
 
 If you would like to be added to the list of contributors posted on the OTA website, simply send us an <a href="mailto:contact@opentermsarchive.org">email</a> or a direct message on our <a href="https://twitter.com/OpenTerms" rel="noopener">Twitter</a> account.
+

--- a/content/static/fr/thanks-gitlab.mdx
+++ b/content/static/fr/thanks-gitlab.mdx
@@ -1,0 +1,7 @@
+## Vous êtes maintenant un contributeur du projet Open Terms Archive
+
+Pour gérer facilement les contributions, nous utilisons les issues GitLab. Nous en avons donc créé une que <a href={url} rel="noopener">vous pouvez voir ici</a>. Cela vous permet de connaître le statut de votre contribution et de communiquer avec nous à son sujet.
+
+Nous faisons de notre mieux pour ajouter votre demande le plus rapidement possible mais cela peut prendre plusieurs jours. En effet, pour garantir une haute qualité des données nous testons chaque contribution pour nous assurer que tout fonctionne parfaitement.
+
+Si vous souhaitez être ajouté à la liste des contributeurs publiée sur le site d'OTA, il vous suffit de nous envoyer un <a href="mailto:contact@opentermsarchive.org">email</a> ou un message direct sur notre compte <a href="https://twitter.com/OpenTerms" target="_blank" rel="noopener">Twitter</a>.

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -26,7 +26,7 @@ import getConfig from 'next/config';
 
 const { publicRuntimeConfig } = getConfig() || {};
 
-const authorizedOrganizations = ['opentermsarchive', 'ambanum'];
+const authorizedOrganizations = ['OpenTermsArchive', 'ambanum'];
 
 const selectorsCheckboxes = [
   '- [ ] **Selectors are:**',

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -23,7 +23,7 @@ import getConfig from 'next/config';
 
 const { publicRuntimeConfig } = getConfig() || {};
 
-const authorizedOrganizations = ['ec-jrc','fabianospinelli','p2b'];
+const authorizedOrganizations = ['OpenTermsArchive', 'ambanum'];
 
 const selectorsCheckboxes = [
   '- [ ] **Selectors are:**',

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -7,9 +7,6 @@ import {
   getDataFromCommit,
 } from 'modules/Github/api';
 import {
-  getProjects, 
-  createProject, 
-  deleteProject, 
   createBranch, 
   commitFile, 
   updateFile, 
@@ -26,7 +23,7 @@ import getConfig from 'next/config';
 
 const { publicRuntimeConfig } = getConfig() || {};
 
-const authorizedOrganizations = ['OpenTermsArchive', 'ambanum'];
+const authorizedOrganizations = ['ec-jrc','fabianospinelli','p2b'];
 
 const selectorsCheckboxes = [
   '- [ ] **Selectors are:**',
@@ -188,10 +185,12 @@ _This suggestion has been created through the [${process.env.NEXT_PUBLIC_CONTRIB
         if (committedFile.hasOwnProperty("message")) {
           if (committedFile.message == 'A file with this name already exists') {
             const existingContent  = await getFileContentRaw('main', this.declarationFilePath);
-            const jsonExistingContent = JSON.parse(existingContent);
-            jsonExistingContent.documents[this.type] = json.documents[this.type];
-            fileContent = JSON.stringify(jsonExistingContent, undefined, 2);
-            await updateFile(branchName as string, this.declarationFilePath as string, fileContent as string);
+            if (typeof existingContent === 'string' && existingContent !== null) {
+              const jsonExistingContent = JSON.parse(existingContent);
+              jsonExistingContent.documents[this.type] = json.documents[this.type];
+              fileContent = JSON.stringify(jsonExistingContent, undefined, 2);
+              await updateFile(branchName as string, this.declarationFilePath as string, fileContent as string);
+            }
           }
         }
         // Create a pull request
@@ -304,10 +303,12 @@ _This update suggestion has been created through the [${process.env.NEXT_PUBLIC_
         await createBranch(branchName as string, 'main');
         //fileContent = JSON.stringify(json, undefined, 2);
         const existingContent  = await getFileContentRaw('main', this.declarationFilePath);
-        const jsonExistingContent = JSON.parse(existingContent);
-        jsonExistingContent.documents[this.type] = json.documents[this.type];
-        fileContent = JSON.stringify(jsonExistingContent, undefined, 2);
-        await updateFile(branchName as string, this.declarationFilePath as string, fileContent as string);
+        if (typeof existingContent === 'string' && existingContent !== null) {
+          const jsonExistingContent = JSON.parse(existingContent);
+          jsonExistingContent.documents[this.type] = json.documents[this.type];
+          fileContent = JSON.stringify(jsonExistingContent, undefined, 2);
+          await updateFile(branchName as string, this.declarationFilePath as string, fileContent as string);
+        }
         // Create a pull request
         const pullRequest = await createPullRequest(branchName as string, 'main', prTitle as string, body as string);
         pullRequest.html_url = pullRequest.web_url;

--- a/src/modules/Common/managers/ServiceManager.ts
+++ b/src/modules/Common/managers/ServiceManager.ts
@@ -6,13 +6,27 @@ import {
   getFileContent,
   getDataFromCommit,
 } from 'modules/Github/api';
+import {
+  getProjects, 
+  createProject, 
+  deleteProject, 
+  createBranch, 
+  commitFile, 
+  updateFile, 
+  createPullRequest,
+  getFileContentRaw,
+  getCommitInfo,
+  getProjectId,
+  getModifiedFilesInCommit
+} from 'modules/Gitlab/api';
 import snakeCase from 'lodash/fp/snakeCase';
 import latinize from 'latinize';
 import { OTAJson } from 'modules/Common/services/open-terms-archive';
 import getConfig from 'next/config';
+
 const { publicRuntimeConfig } = getConfig() || {};
 
-const authorizedOrganizations = ['OpenTermsArchive', 'ambanum'];
+const authorizedOrganizations = ['opentermsarchive', 'ambanum'];
 
 const selectorsCheckboxes = [
   '- [ ] **Selectors are:**',
@@ -102,6 +116,13 @@ export default class ServiceManager {
       return this.addService({ json, url, localUrl });
     }
 
+    if (process.env.NEXT_PUBLIC_REPO_TYPE == 'GITLAB') {
+      return this.updateService({
+        json,
+        url,
+        localUrl,
+      });
+    } else {
     try {
       const { lastFailingDate, issueNumber } = await getLatestFailDate({
         ...this.commonParams,
@@ -122,6 +143,7 @@ export default class ServiceManager {
         localUrl,
       });
     }
+  }
   }
 
   public async addService({ json, url, localUrl }: { json: any; url: string; localUrl: string }) {
@@ -153,24 +175,46 @@ Thanks to your work and attention, Open Terms Archive will ensure that high qual
 
 - - -
 
-_This suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can load it [on your local instance](${localUrl}) if you have one set up._
+_This suggestion has been created through the [${process.env.NEXT_PUBLIC_CONTRIBUTION_TOOL_LABEL}](${process.env.NEXT_PUBLIC_CONTRIBUTION_TOOL_URL}), which enables graphical declaration of documents. You can load it [on your local instance](${localUrl}) if you have one set up._
 `;
 
-    try {
-      return await createDocumentAddPullRequest({
-        ...this.commonParams,
-        targetBranch: 'main',
-        newBranch: branchName,
-        title: prTitle,
-        message: prTitle,
-        content: json,
-        author: this.author,
-        filePath: this.declarationFilePath,
-        body,
-      });
-    } catch (e: any) {
-      if (e?.response?.data?.message === 'Reference already exists') {
-        const updateBody = `### [🔎 Inspect the updated declaration suggestion](${url})
+    if (process.env.NEXT_PUBLIC_REPO_TYPE == 'GITLAB') {
+      return await (async () => {
+        let fileContent;
+        // Create a new branch
+        await createBranch(branchName as string, 'main');
+        fileContent = JSON.stringify(json, undefined, 2);
+        const committedFile = await commitFile(branchName as string, this.declarationFilePath as string, fileContent as string);
+        if (committedFile.hasOwnProperty("message")) {
+          if (committedFile.message == 'A file with this name already exists') {
+            const existingContent  = await getFileContentRaw('main', this.declarationFilePath);
+            const jsonExistingContent = JSON.parse(existingContent);
+            jsonExistingContent.documents[this.type] = json.documents[this.type];
+            fileContent = JSON.stringify(jsonExistingContent, undefined, 2);
+            await updateFile(branchName as string, this.declarationFilePath as string, fileContent as string);
+          }
+        }
+        // Create a pull request
+        const pullRequest = await createPullRequest(branchName as string, 'main', prTitle as string, body as string);
+        pullRequest.html_url = pullRequest.web_url;
+        return pullRequest;
+      }) ();
+    } else {
+      try {
+        return await createDocumentAddPullRequest({
+          ...this.commonParams,
+          targetBranch: 'main',
+          newBranch: branchName,
+          title: prTitle,
+          message: prTitle,
+          content: json,
+          author: this.author,
+          filePath: this.declarationFilePath,
+          body,
+        });
+      } catch (e: any) {
+        if (e?.response?.data?.message === 'Reference already exists') {
+          const updateBody = `### [🔎 Inspect the updated declaration suggestion](${url})
 
 A new suggestion has been made, voiding the previous ones. As a human reviewer, here are the things you should check:
 
@@ -178,23 +222,25 @@ ${checkBoxes.join('\n')}
 
 - - -
 
-_This suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can load it [on your local instance](${localUrl}) if you have one set up._
+_This suggestion has been created through the [${process.env.NEXT_PUBLIC_CONTRIBUTION_TOOL_LABEL}](${process.env.NEXT_PUBLIC_CONTRIBUTION_TOOL_URL}), which enables graphical declaration of documents. You can load it [on your local instance](${localUrl}) if you have one set up._
 `;
-        // a branch already exists wit this name, add a commit to it
-        return await updateDocumentsInBranch({
-          ...this.commonParams,
-          branch: branchName,
-          targetBranch: 'main',
-          content: json,
-          filePath: this.declarationFilePath,
-          message: `Update ${json.name} ${this.type} declaration`,
-          title: prTitle,
-          author: this.author,
-          body: updateBody,
-        });
+          // a branch already exists wit this name, add a commit to it
+          return await updateDocumentsInBranch({
+            ...this.commonParams,
+            branch: branchName,
+            targetBranch: 'main',
+            content: json,
+            filePath: this.declarationFilePath,
+            message: `Update ${json.name} ${this.type} declaration`,
+            title: prTitle,
+            author: this.author,
+            body: updateBody,
+          });
+        }
+        throw e;
       }
-      throw e;
     }
+
   }
 
   public async updateService({
@@ -214,8 +260,10 @@ _This suggestion has been created through the [Contribution Tool](https://github
     const branchName = snakeCase(prTitle);
     const hasSelector = !!json?.documents[this.type]?.select;
 
-    const validUntilCheckboxes = !lastFailingDate
-      ? [
+    let validUntilCheckboxes: string[] = [];
+    if (process.env.NEXT_PUBLIC_REPO_TYPE != 'GITLAB') {
+      validUntilCheckboxes = !lastFailingDate
+        ? [
           '- [ ] **`validUntil` date is correctly input** in the history file. To get that date, you can use the following method. In all cases where a date is to be obtained from the GitHub user interface, you can obtain the exact datetime by hovering your cursor over the date or using the developer tools to copy its `datetime` attribute.',
           '  1. Find the date at which the problem was first encountered:',
           '    - If there is one, find the first date at which an issue was opened claiming that the terms can not be tracked anymore.',
@@ -223,8 +271,9 @@ _This suggestion has been created through the [Contribution Tool](https://github
           `    - If the document can not be fetched anymore, [find the latest snapshot](${this.getSnapshotsURL()}).`,
           `  2. Find the most recent snapshot that is strictly anterior to this date from the [snapshots database](${this.getSnapshotsURL()}).`,
           '  3. Set the creation date of this snapshot as the `validUntil` date in the [history file](./files).',
-        ]
-      : [];
+          ]
+        : [];
+    }
 
     const checkBoxes = [
       ...(hasSelector ? selectorsCheckboxes : []),
@@ -245,9 +294,26 @@ Thanks to your work and attention, Open Terms Archive will ensure that high qual
 ${issueNumber ? `Fixes #${issueNumber}` : ''}
 - - -
 
-_This update suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can load it [on your local instance](${localUrl}) if you have one set up._
+_This update suggestion has been created through the [${process.env.NEXT_PUBLIC_CONTRIBUTION_TOOL_LABEL}](${process.env.NEXT_PUBLIC_CONTRIBUTION_TOOL_URL}), which enables graphical declaration of documents. You can load it [on your local instance](${localUrl}) if you have one set up._
 `;
 
+    if (process.env.NEXT_PUBLIC_REPO_TYPE == 'GITLAB') {
+      return await (async () => {
+        let fileContent;
+        // Create a new branch
+        await createBranch(branchName as string, 'main');
+        //fileContent = JSON.stringify(json, undefined, 2);
+        const existingContent  = await getFileContentRaw('main', this.declarationFilePath);
+        const jsonExistingContent = JSON.parse(existingContent);
+        jsonExistingContent.documents[this.type] = json.documents[this.type];
+        fileContent = JSON.stringify(jsonExistingContent, undefined, 2);
+        await updateFile(branchName as string, this.declarationFilePath as string, fileContent as string);
+        // Create a pull request
+        const pullRequest = await createPullRequest(branchName as string, 'main', prTitle as string, body as string);
+        pullRequest.html_url = pullRequest.web_url;
+        return pullRequest;
+      }) ();
+    } else {
     try {
       return await createDocumentUpdatePullRequest({
         ...this.commonParams,
@@ -273,7 +339,7 @@ ${checkBoxes.join('\n')}
 
 - - -
 
-_This suggestion has been created through the [Contribution Tool](https://github.com/OpenTermsArchive/contribution-tool/), which enables graphical declaration of documents. You can load it [on your local instance](${localUrl}) if you have one set up._
+_This suggestion has been created through the [${process.env.NEXT_PUBLIC_CONTRIBUTION_TOOL_LABEL}](${process.env.NEXT_PUBLIC_CONTRIBUTION_TOOL_URL}), which enables graphical declaration of documents. You can load it [on your local instance](${localUrl}) if you have one set up._
 `;
 
       // a branch already exists wit this name, add a commit to it
@@ -291,6 +357,7 @@ _This suggestion has been created through the [Contribution Tool](https://github
         title: prTitle,
         body: updateBody,
       });
+    }
     }
   }
 
@@ -313,12 +380,19 @@ _This suggestion has been created through the [Contribution Tool](https://github
   }
 
   getDeclarationFiles = async () => {
-    const { content: existingContentString } = await getFileContent({
-      ...this.commonParams,
-      filePath: this.declarationFilePath,
-      branch: 'main',
-    });
-
+    let existingContentString; 
+    if (process.env.NEXT_PUBLIC_REPO_TYPE == 'GITLAB') {
+      const existingContent  = await getFileContentRaw('main', this.declarationFilePath);
+      existingContentString = existingContent;
+    } else {
+      const { content: existingContent } = await getFileContent({
+        ...this.commonParams,
+        filePath: this.declarationFilePath,
+        branch: 'main',
+      });
+      existingContentString = existingContent;
+    }
+    
     if (!existingContentString) {
       return { declaration: null };
     }
@@ -340,21 +414,41 @@ _This suggestion has been created through the [Contribution Tool](https://github
   static getDataFromCommit = async (commitURL: string) => {
     const { pathname } = new URL(commitURL);
 
-    let [repo, commitId] = pathname.replace(/^\//g, '').split('/commit/');
+    let repo, commitId;
+    if (process.env.NEXT_PUBLIC_REPO_TYPE == 'GITLAB') {
+      const urlObj = new URL(commitURL);
+      const pathParts = urlObj.pathname.split('/');
+      repo = pathParts[1] + '/' + pathParts[2];
+      [repo, commitId] = pathname.replace(/^\//g, '').split('/-/commit/');
+    } else {
+       [repo, commitId] = pathname.replace(/^\//g, '').split('/commit/'); 
+    }
     const { githubOrganization, githubRepository } =
       ServiceManager.getOrganizationAndRepository(repo);
 
-    const { commit, files } = await getDataFromCommit({
-      commitId,
-      owner: githubOrganization,
-      repo: githubRepository,
-    });
+    let commit, files;
+    if (process.env.NEXT_PUBLIC_REPO_TYPE == 'GITLAB') {
+      let projectId = await getProjectId(repo);
+      commit = await getCommitInfo(commitId, projectId);
+      files = await getModifiedFilesInCommit(commitId, projectId);
+    } else {
+      ({ commit, files } = await getDataFromCommit({
+        commitId,
+        owner: githubOrganization,
+        repo: githubRepository,
+      }));
+    }
 
     if (!files || files.length === 0) {
       throw new Error(`Commit ${commitURL} could not be retrieved`);
     }
-
-    const filename = files[0].filename.replace(/\.md$/, '');
+    
+    let filename;
+    if (process.env.NEXT_PUBLIC_REPO_TYPE == 'GITLAB') {
+      filename = files[0].new_path.replace(/\.md$/, '');
+    } else {
+      filename = files[0].filename.replace(/\.md$/, '');
+    }
     const [service, documentType] = filename.split('/');
 
     return {

--- a/src/modules/Gitlab/api/index.ts
+++ b/src/modules/Gitlab/api/index.ts
@@ -1,0 +1,151 @@
+const gitlabUrl = process.env.GITLAB_URL;
+const accessToken = process.env.GITLAB_TOKEN;
+const projectId = process.env.GITLAB_PROJECT_ID;
+
+export async function getProjects() {
+  const response = await fetch(`${gitlabUrl}/projects`, {
+  headers: {
+      'Authorization': `Bearer ${accessToken}`
+    }
+  });
+  return response.json();
+}
+
+export async function createProject(projectName: string) {
+  const response = await fetch(`${gitlabUrl}/projects`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${accessToken}`
+    },
+    body: JSON.stringify({ name: projectName })
+  });
+  return response.json();
+}
+
+export async function deleteProject(projectId: string) {
+  const response = await fetch(`${gitlabUrl}/projects/${projectId}`, {
+    method: 'DELETE',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`
+    }
+  });
+  return response.json();
+}
+
+export async function createBranch(branchName: string, ref: string) {
+  const response = await fetch(`${gitlabUrl}/projects/${projectId}/repository/branches`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${accessToken}`
+    },
+    body: JSON.stringify({ branch: branchName, ref: ref })
+  });
+  return response.json();
+}
+
+export async function commitFile(branchName: string, filePath: string, content: string) {
+  const response = await fetch(`${gitlabUrl}/projects/${projectId}/repository/commits`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${accessToken}`
+    },
+    body: JSON.stringify({ branch: branchName, commit_message: `Adding ${filePath}`, actions: [ { action: `create`, file_path: `${filePath}`, content: content} ] })
+  });
+  return response.json();
+}
+
+export async function updateFile(branchName: string, filePath: string, content: string) {
+  const response = await fetch(`${gitlabUrl}/projects/${projectId}/repository/commits`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${accessToken}`
+    },
+    body: JSON.stringify({ branch: branchName, commit_message: `Updating ${filePath}`, actions: [ { action: `update`, file_path: `${filePath}`, content: content} ] })
+  });
+  return response.json();
+}
+
+export async function createPullRequest(sourceBranch: string, targetBranch: string, title: string, description: string) {
+  const response = await fetch(`${gitlabUrl}/projects/${projectId}/merge_requests`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json,',
+      'Authorization': `Bearer ${accessToken}`
+    },
+    body: JSON.stringify({ source_branch: sourceBranch, target_branch: targetBranch, title, description })
+  });
+  return response.json();
+}
+
+export async function getFileContentRaw(branchName: string, filePath: string) {
+  const response = await fetch(`${gitlabUrl}/projects/${projectId}/repository/files/${encodeURIComponent(filePath)}/raw?ref=${branchName}`, {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`
+    }
+  });
+  if (response.ok) {
+    return response.text();
+  } else {
+    return null;
+  }
+}
+
+export async function getCommitInfo(commitId: string, sourceProjectId: string) {
+  const response = await fetch(`${gitlabUrl}/projects/${sourceProjectId}/repository/commits/${commitId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${accessToken}`
+    }
+  });
+  if (response.ok) {
+    return response.json();
+  } else {
+    return null;
+  }
+}
+
+export async function getProjectId(repositoryPath: string) {
+    const url = `${gitlabUrl}/projects/${encodeURIComponent(repositoryPath)}`;
+    const headers = {
+    };
+
+    try {
+        const response = await fetch(url, { headers });
+        if (response.ok) {
+            const projectData = await response.json();
+            return projectData.id;
+        } else {
+            console.error(`Failed to retrieve project details: ${response.status} - ${response.statusText}`);
+            return null;
+        }
+    } catch (error) {
+        console.error('Error fetching project details:', error);
+        return null;
+    }
+}
+
+export async function getModifiedFilesInCommit(commitId: string, sourceProjectId: string) {
+    const url = `${gitlabUrl}/projects/${sourceProjectId}/repository/commits/${commitId}/diff`;
+    const headers = {
+    };
+
+    try {
+        const response = await fetch(url, { headers });
+        if (response.ok) {
+            const commitData = await response.json();
+            return commitData;
+        } else {
+            console.error(`Failed to retrieve commit details: ${response.status} - ${response.statusText}`);
+            return null;
+        }
+    } catch (error) {
+        console.error('Error fetching commit details:', error);
+        return null;
+    }
+}

--- a/src/pages/api/services/index.ts
+++ b/src/pages/api/services/index.ts
@@ -65,7 +65,7 @@ const get =
             status: 'ko',
             message: 'Could not download url',
             url: '',
-            error: "URL seems to be a private address and has been blocked"
+	    error: "URL seems to be a private address and has been blocked"
           });
           return res;
         }

--- a/src/pages/homepage.tsx
+++ b/src/pages/homepage.tsx
@@ -77,10 +77,10 @@ const HomePage = ({ mdxContent }: WithMdxResult) => {
           <TextContent>
             <h2>{t('homepage:edit.title')}</h2>
             <div className={classNames('formfield')}>
-              <label htmlFor="github-commit">{t('homepage:edit.subtitle')}</label>
+              <label htmlFor="github-commit">{process.env.NEXT_PUBLIC_REPO_TYPE === 'GITLAB' ? t('homepage:edit.subtitle').replace('GitHub', 'GitLab') : t('homepage:edit.subtitle')}</label>
               <input
                 id="github-commit"
-                placeholder="https://github.com/OpenTermsArchive/contrib-versions/commit/76b17c1038ba610c010c7fb271ae04196de1e19a"
+                placeholder={process.env.NEXT_PUBLIC_REPO_TYPE === 'GITLAB' ? 'https://gitlab.com/OpenTermsArchive/contrib-versions/-/commit/ef851572217a809bd0045282bb530203eefccada' : 'https://github.com/OpenTermsArchive/contrib-versions/commit/76b17c1038ba610c010c7fb271ae04196de1e19a'}
                 onInput={onUseCommit}
               />
             </div>

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -179,7 +179,7 @@ const ServicePage = ({
 
   const onValidate = async (name: string, email: string) => {
     toggleLoading(true);
-
+   
     try {
       const {
         data: { url, message },
@@ -194,7 +194,7 @@ const ServicePage = ({
       });
 
       if (!url) {
-        const subject = 'Here is a new service to track in Open Terms Archive';
+        const subject = 'Here is a new service to track in Open Terms Archive';
         const body = `Hi,
 
   I need you to track "${documentType}" of "${declaration?.name}" for me.
@@ -694,8 +694,10 @@ Thank you very much`;
   );
 };
 
-export const getStaticProps = async (props: any) =>
-  JSON.parse(
+export const getStaticProps = async (props: any) => {
+  let filename_repo = process.env.NEXT_PUBLIC_REPO_TYPE === "GITLAB" ? "contributor-form-gitlab" : "contributor-form";
+
+  return JSON.parse(
     JSON.stringify({
       props: {
         ...props,
@@ -704,13 +706,14 @@ export const getStaticProps = async (props: any) =>
           {
             load: 'mdx',
             folder: 'parts',
-            filename: 'contributor-form',
+            filename: filename_repo,
           },
           props.locale
         ),
       },
       revalidate: 60 * 5,
     })
-  );
+  )
+};
 
 export default ServicePage;

--- a/src/pages/thanks.tsx
+++ b/src/pages/thanks.tsx
@@ -22,7 +22,7 @@ export default function ThanksPage({ mdxContent }: WithMdxResult) {
   return (
     <Layout title={t('thanks:seo.title')} desc={t('thanks:seo.desc')}>
       {/* Hero */}
-      <Container layout="wide" paddingY={false} dark={true} bgColor="#010613">
+      <Container layout="wide" paddingY={false} dark={true} bgColor="#004694">
         <Container gridCols="12" gridGutters="11" flex={true} paddingX={false}>
           <Hero title={t('thanks:title')}></Hero>
         </Container>
@@ -51,4 +51,10 @@ export default function ThanksPage({ mdxContent }: WithMdxResult) {
     </Layout>
   );
 }
-export const getStaticProps = withMdx({ load: 'mdx', filename: 'thanks', folder: 'static' })();
+
+export const getStaticProps = withMdx({ 
+  load: 'mdx', 
+  filename: process.env.NEXT_PUBLIC_REPO_TYPE === "GITLAB" ? 'thanks-gitlab' : 'thanks',
+  folder: 'static' 
+})();
+

--- a/src/pages/thanks.tsx
+++ b/src/pages/thanks.tsx
@@ -22,7 +22,7 @@ export default function ThanksPage({ mdxContent }: WithMdxResult) {
   return (
     <Layout title={t('thanks:seo.title')} desc={t('thanks:seo.desc')}>
       {/* Hero */}
-      <Container layout="wide" paddingY={false} dark={true} bgColor="#004694">
+      <Container layout="wide" paddingY={false} dark={true} bgColor="#010613">
         <Container gridCols="12" gridGutters="11" flex={true} paddingX={false}>
           <Hero title={t('thanks:title')}></Hero>
         </Container>


### PR DESCRIPTION
As previously anticipated, we needed to use the GitLab platform instead of GitHub, which was already present in the Contribution-Tool application. Therefore, a number of changes were made in the code by adding a module that allows using the GitLab API. A number of variables were added in the .env file that allow projects/repositories to be configured on any GitLab compatible platform/url.
The code has been fully tested several times (below is a list of the tests performed) and we submit it to you to verify or receive suggestions: it is clear that our need was to have such functionality as quickly as possible for this reason we tried to modify the application minimally.

Here the list of tests we made to verify that everything works fine with the application:

**GitLab**
- Added a new declaration for Netflix related to the Privacy Policy.
- Tried to re-insert previous declaration before approving PR (got error message correctly, just need to change a description - PR available on Github)
- Added a new declaration always related to Netflix but with a Terms & Conditions different from Privacy Policy
- Added a new declaration for Inter F.C. related to Privacy Policy
- Updated a declaration for Alibaba.com (already existing on the repository) related to Market Buyers Conditions
- Added a new declaration for Alibaba.com (already existing on the repository) but of type Terms of Service

**GitHub**
- Added a new declaration for BYD of type Terms of Service.
- Updated the declaration for BYD by changing the Terms of Service type.
- Added a new declaration for Netflix related to the Privacy Policy

We remain available for any clarification.

Thanks,
Fabiano