### PR TITLE
Update dynamic title to identify corresponding issues

### DIFF
--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -383,7 +383,7 @@ export const getLatestFailDate = async ({ serviceName, documentType, ...commonPa
     const issues = await searchIssues({
       ...commonParams,
       state: 'open',
-      title: `${serviceName} ‧ ${documentType} ‧ not tracked anymore`,
+      title: `\`${serviceName}\` ‧ \`${documentType}\` ‧ not tracked anymore`,
     });
     const issue = issues[0];
 

--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -415,9 +415,8 @@ export const getLatestFailDate = async ({ serviceName, documentType, ...commonPa
     const failingComments = allComments.filter(
       ({ body }) =>
         body &&
-        (body.startsWith('🤖 Reopened') ||
-          body.includes('no longer properly tracked') ||
-          body.includes('not available anymore'))
+        body.includes('No version of the') &&
+        body.includes('is recorded anymore since')
     );
 
     const mostRecentFailingComment = failingComments[failingComments.length - 1];

--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -383,7 +383,7 @@ export const getLatestFailDate = async ({ serviceName, documentType, ...commonPa
     const issues = await searchIssues({
       ...commonParams,
       state: 'open',
-      title: `Fix ${serviceName} - ${documentType}`,
+      title: `${serviceName} ‧ ${documentType} ‧ not tracked anymore`,
     });
     const issue = issues[0];
 


### PR DESCRIPTION
Automatic determination of the `validUntil` value from the corresponding issue/comments and incorporation of it in history files appears to have worked previously but may no longer be possible from the breaking change noted in [this PR](https://github.com/OpenTermsArchive/engine/pull/1025/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16).

Changes here update the identification syntax to be the same as [the format](https://github.com/OpenTermsArchive/engine/blob/main/src/reporter/index.js#L188) used in the engine so the `validUntil` information can be found and included automatically. The format is also observable in the [issue titles](https://github.com/OpenTermsArchive/contrib-declarations/issues).

Should resolve this issue: https://github.com/OpenTermsArchive/contribution-tool/issues/179