### PR TITLE
Add environment variables used in service manager

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENV: production
+      NEXT_PUBLIC_CONTRIBUTION_TOOL_LABEL: "Contribution Tool"
+      NEXT_PUBLIC_CONTRIBUTION_TOOL_URL: "https://github.com/OpenTermsArchive/contribution-tool"
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
These values are being referenced [here](https://github.com/search?q=repo%3AOpenTermsArchive%2Fcontribution-tool%20%22created%20through%20the%22&type=code) but do not appear to be set.

Should resolve: https://github.com/OpenTermsArchive/contribution-tool/issues/182

These values could be added as secrets or in other ways, but as the workflow exists in `.github/` and these aren't actually _secret_ values, it seems fine to add these here.

[This commit](https://github.com/OpenTermsArchive/contribution-tool/commit/681e8f02ae5dec3f8e0c444e5eae1dbac22af6a2) converted the message to use environment variables so that the code was usable on Gitlab.

I'm not sure if these are important to add to other workflows such as: https://github.com/OpenTermsArchive/contribution-tool/blob/main/.github/workflows/deploy-preprod.yml