### PR TITLE
Replace links to Twitter with Mastodon

### DIFF
--- a/content/static/en/thanks.mdx
+++ b/content/static/en/thanks.mdx
@@ -2,6 +2,4 @@
 
 Your suggestion has been turned to a <a href={url} target="_blank">pull request</a> on {platform}. You can follow the status of your suggestion there and communicate with us about it by creating an account on {platform}.
 
-In order to guarantee a high quality of data, we test each contribution individually to make sure it works as intended and is stable over time. We do our best to start tracking the document you suggested as fast as possible, but these checks may take a few days.
-
-If you would like to be added to the list of contributors posted on the OTA website, simply send us an <a href="mailto:contact@opentermsarchive.org">email</a> or a direct message on our <a href="https://twitter.com/OpenTerms" rel="noopener">Twitter</a> account.
+In order to guarantee a high quality of data, each contribution is individually reviewed to make sure it works as intended and is stable over time. We do our best to start tracking the document you suggested as fast as possible, but these checks may take a few days.

--- a/content/static/fr/thanks.mdx
+++ b/content/static/fr/thanks.mdx
@@ -2,6 +2,4 @@
 
 Pour gérer facilement les contributions, nous utilisons les issues {platform}. Nous en avons donc créé une que <a href={url} rel="noopener">vous pouvez voir ici</a>. Cela vous permet de connaître le statut de votre contribution et de communiquer avec nous à son sujet.
 
-Nous faisons de notre mieux pour ajouter votre demande le plus rapidement possible mais cela peut prendre plusieurs jours. En effet, pour garantir une haute qualité des données nous testons chaque contribution pour nous assurer que tout fonctionne parfaitement.
-
-Si vous souhaitez être ajouté à la liste des contributeurs publiée sur le site d'OTA, il vous suffit de nous envoyer un <a href="mailto:contact@opentermsarchive.org">email</a> ou un message direct sur notre compte <a href="https://twitter.com/OpenTerms" target="_blank" rel="noopener">Twitter</a>.
+Pour garantir une haute qualité des données nous testons chaque contribution pour nous assurer que tout fonctionne correctement. Nous faisons de notre mieux pour traiter votre ajout rapidement, mais ces vérificaitons peuvent prendre plusieurs jours.

--- a/locales/en/footer.json
+++ b/locales/en/footer.json
@@ -2,5 +2,7 @@
   "link.contact": "Contact us",
   "link.contact.title": "Contact us by mail",
   "link.github": "Source code",
-  "link.github.title": "Go to the GitHub repository"
+  "link.github.title": "Go to the GitHub repository",
+  "link.mastodon": "Follow us",
+  "link.mastodon.title": "Follow us on Mastodon"
 }

--- a/locales/en/footer.json
+++ b/locales/en/footer.json
@@ -2,7 +2,5 @@
   "link.contact": "Contact us",
   "link.contact.title": "Contact us by mail",
   "link.github": "Source code",
-  "link.github.title": "Go to the GitHub repository",
-  "link.twitter": "Follow us",
-  "link.twitter.title": "Follow us on Twitter"
+  "link.github.title": "Go to the GitHub repository"
 }

--- a/locales/en/header.json
+++ b/locales/en/header.json
@@ -1,6 +1,5 @@
 {
   "close": "Close",
   "link.github.title": "See the source code",
-  "link.twitter.title": "Follow us",
   "open": "Menu"
 }

--- a/locales/fr/footer.json
+++ b/locales/fr/footer.json
@@ -2,5 +2,7 @@
   "link.contact": "Contactez-nous",
   "link.contact.title": "Contactez nous par email",
   "link.github": "Code source",
-  "link.github.title": "Voir le code source"
+  "link.github.title": "Voir le code source",
+  "link.mastodon": "Suivez-nous",
+  "link.mastodon.title": "Suivez-nous sur Mastodon"
 }

--- a/locales/fr/footer.json
+++ b/locales/fr/footer.json
@@ -2,7 +2,5 @@
   "link.contact": "Contactez-nous",
   "link.contact.title": "Contactez nous par email",
   "link.github": "Code source",
-  "link.github.title": "Voir le code source",
-  "link.twitter": "Suivez-nous",
-  "link.twitter.title": "Suivez-nous sur Twitter"
+  "link.github.title": "Voir le code source"
 }

--- a/locales/fr/header.json
+++ b/locales/fr/header.json
@@ -1,6 +1,5 @@
 {
   "close": "Fermer",
   "link.github.title": "Voir le code source",
-  "link.twitter.title": "Suivez-nous sur Twitter",
   "open": "Menu"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-hook-form": "^7.27.1",
-        "react-icons": "^4.3.1",
+        "react-icons": "^4.12.0",
         "react-markdown": "^8.0.3",
         "react-toastify": "^8.2.0",
         "react-use": "^17.3.2",
@@ -17154,9 +17154,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
-      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8374,9 +8374,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001550",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001550.tgz",
-      "integrity": "sha512-p82WjBYIypO0ukTsd/FG3Xxs+4tFeaY9pfT4amQL8KWtYH7H9nYwReGAbMTJ0hsmRO8IfDtsS6p3ZWj8+1c2RQ==",
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -8390,7 +8390,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-hook-form": "^7.27.1",
-    "react-icons": "^4.3.1",
+    "react-icons": "^4.12.0",
     "react-markdown": "^8.0.3",
     "react-toastify": "^8.2.0",
     "react-use": "^17.3.2",

--- a/src/modules/Common/containers/CommonHead.tsx
+++ b/src/modules/Common/containers/CommonHead.tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import React from 'react';
 import { useRouter } from 'next/router';
-const twitterUser = 'OpenTerms';
 const websiteName = 'opentermsarchive.org';
 const type = 'website';
 
@@ -52,7 +51,6 @@ export default function CommonHead({
       <meta name="twitter:title" content={title} />
       {description && <meta name="twitter:description" content={description} />}
       <meta name="twitter:image" content={twitterCard} />
-      {twitterUser && <meta name="twitter:site" content={twitterUser} />}
 
       {/* OPENGRAPH https://ogp.me/ */}
       <meta property="og:title" content={title} />

--- a/src/modules/Common/containers/Layout.tsx
+++ b/src/modules/Common/containers/Layout.tsx
@@ -1,4 +1,5 @@
 import { FiGithub, FiMail } from 'react-icons/fi';
+import { FaMastodon } from 'react-icons/fa';
 import React, { ReactNode } from 'react';
 
 import { Analytics } from 'modules/Analytics';
@@ -42,6 +43,20 @@ const Layout = ({
                   <LanguageSwitcher />
                   <ul>
                     <li>
+                      <Link href="https://mastodon.social/@opentermsarchive">
+                        <a
+                          target="_blank"
+                          rel="noopener"
+                          title={t('footer:link.mastodon.title')}
+                          className={classNames('a_icontext', 'a__small', 'footer_menus_icontext')}
+                        >
+                          <span className={classNames('icon_circle', 'mr__2XS')}>
+                            <FaMastodon color="#fefffd" />
+                          </span>
+                        </a>
+                      </Link>
+                    </li>
+                    <li>
                       <Link href="https://github.com/OpenTermsArchive/contribution-tool">
                         <a
                           className={classNames('icon_circle')}
@@ -77,6 +92,21 @@ const Layout = ({
           <Footer>
             <FooterMenu>
               <ul>
+                <li>
+                  <Link href="https://mastodon.social/@opentermsarchive">
+                    <a
+                      target="_blank"
+                      rel="noopener"
+                      title={t('footer:link.mastodon.title')}
+                      className={classNames('a_icontext', 'a__small', 'footer_menus_icontext')}
+                    >
+                      <span className={classNames('icon_circle', 'icon_circle__medium', 'mr__2XS')}>
+                        <FaMastodon color="#fefffd" />
+                      </span>
+                      <span>{t('footer:link.mastodon')}</span>
+                    </a>
+                  </Link>
+                </li>
                 <li>
                   <Link href="mailto:contact@opentermsarchive.org">
                     <a

--- a/src/modules/Common/containers/Layout.tsx
+++ b/src/modules/Common/containers/Layout.tsx
@@ -1,4 +1,4 @@
-import { FiGithub, FiMail, FiTwitter } from 'react-icons/fi';
+import { FiGithub, FiMail } from 'react-icons/fi';
 import React, { ReactNode } from 'react';
 
 import { Analytics } from 'modules/Analytics';
@@ -42,18 +42,6 @@ const Layout = ({
                   <LanguageSwitcher />
                   <ul>
                     <li>
-                      <Link href="https://twitter.com/OpenTerms">
-                        <a
-                          className={classNames('icon_circle')}
-                          target="_blank"
-                          rel="noopener"
-                          title={t('header:link.twitter.title')}
-                        >
-                          <FiTwitter color="#fefffd" />
-                        </a>
-                      </Link>
-                    </li>
-                    <li>
                       <Link href="https://github.com/OpenTermsArchive/contribution-tool">
                         <a
                           className={classNames('icon_circle')}
@@ -89,21 +77,6 @@ const Layout = ({
           <Footer>
             <FooterMenu>
               <ul>
-                <li>
-                  <Link href="https://twitter.com/OpenTerms">
-                    <a
-                      target="_blank"
-                      rel="noopener"
-                      title={t('footer:link.twitter.title')}
-                      className={classNames('a_icontext', 'a__small', 'footer_menus_icontext')}
-                    >
-                      <span className={classNames('icon_circle', 'icon_circle__medium', 'mr__2XS')}>
-                        <FiTwitter color="#fefffd" />
-                      </span>
-                      <span>{t('footer:link.twitter')}</span>
-                    </a>
-                  </Link>
-                </li>
                 <li>
                   <Link href="mailto:contact@opentermsarchive.org">
                     <a


### PR DESCRIPTION
Obsolete 𝕏 account was taken over by a third party, as spotted by @clementbiron.

### Before

<img width="343" height="83" alt="Screenshot 2025-07-16 at 13 53 00" src="https://github.com/user-attachments/assets/3bd294cc-a8ab-41e9-95dd-0447b2cade29" />

### After

<img width="393" height="73" alt="Screenshot 2025-07-16 at 13 52 50" src="https://github.com/user-attachments/assets/11b5ede8-edcc-4120-8f75-289e545e810b" />
